### PR TITLE
fix: disable Jekyll for GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Build
         run: bun run build
 
+      - name: Disable Jekyll
+        run: touch dist/.nojekyll
+
       - name: Setup Pages
         uses: actions/configure-pages@v4
 


### PR DESCRIPTION
## Summary

GitHub Pages uses Jekyll by default to build sites, but we're using Astro with a custom build process. This adds a  file to the build output to prevent Jekyll from processing our site.

## Changes

- Added step to create  file in the  folder after build
- This tells GitHub Pages to serve the files as-is without Jekyll processing

## Why

Without this, GitHub Pages would try to process the Astro build output with Jekyll, which could:
- Ignore files starting with underscore (common in Astro)
- Process Liquid templates incorrectly
- Cause routing issues

## Testing

Once merged, the deployment workflow should complete successfully and the site will be available at https://abijith-suresh.github.io/reshrimp/