### PR TITLE
docs: clarify PR merge strategy in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,7 @@ type(scope): subject
 3. Push branch: `git push -u origin feat/your-feature-name`
 4. Create PR: `gh pr create --title "feat: add feature" --body "Description"`
 5. Wait for CI checks (lint, format, build) to pass
-6. Merge using squash merge
+6. Merge using regular merge commit (not squash) with a clean message
 7. Delete branch after merge
 
 ## Code Style


### PR DESCRIPTION
## Summary

Updated AGENTS.md to clarify that PRs should be merged using regular merge commits (not squash merge) with clean, descriptive commit messages.

This ensures better commit history traceability and follows the documented workflow established in the animation jank PR (#6).

## Changes

- Updated PR merge step to specify "regular merge commit (not squash) with a clean message"

## Test plan

- ✅ No code changes, documentation only
- ✅ Formatting and lint checks pass