### PR TITLE
feat(changelog): add changelog route and SPA animations

### DIFF
--- a/src/components/shared/Footer.astro
+++ b/src/components/shared/Footer.astro
@@ -11,6 +11,7 @@ const footerLinks = [
   { label: "Features", path: ROUTES.FEATURES },
   { label: "Privacy", path: ROUTES.PRIVACY },
   { label: "Blog", path: ROUTES.BLOG },
+  { label: "Changelog", path: ROUTES.CHANGELOG },
   { label: "About", path: ROUTES.ABOUT },
   { label: "FAQ", path: ROUTES.FAQ },
 ];

--- a/src/components/shared/Header.astro
+++ b/src/components/shared/Header.astro
@@ -13,7 +13,7 @@ function makeHref(path: string): string {
 }
 ---
 
-<header class="sp-header" transition:animate="fade">
+<header class="sp-header" id="sp-header" transition:animate="fade">
   <nav class="sp-header-inner">
     <a href={makeHref("/")} class="sp-logo" transition:name="logo">
       <span class="sp-logo-dot"></span>
@@ -57,6 +57,7 @@ function makeHref(path: string): string {
       aria-expanded="false"
     >
       <svg
+        class="sp-hamburger-icon"
         width="24"
         height="24"
         viewBox="0 0 24 24"
@@ -65,29 +66,31 @@ function makeHref(path: string): string {
         stroke-width="2"
         stroke-linecap="round"
       >
-        <line x1="3" y1="6" x2="21" y2="6"></line>
-        <line x1="3" y1="12" x2="21" y2="12"></line>
-        <line x1="3" y1="18" x2="21" y2="18"></line>
+        <line class="ham-line-1" x1="3" y1="6" x2="21" y2="6"></line>
+        <line class="ham-line-2" x1="3" y1="12" x2="21" y2="12"></line>
+        <line class="ham-line-3" x1="3" y1="18" x2="21" y2="18"></line>
       </svg>
     </button>
   </nav>
 
-  <!-- Mobile menu -->
+  <!-- Mobile menu — slide animation via max-height -->
   <div class="sp-mobile-panel" id="mobile-menu-panel">
-    {
-      NAV_LINKS.map((link) => (
-        <a
-          href={makeHref(link.path)}
-          class:list={["sp-mobile-link", { "sp-mobile-link-active": currentPath === link.path }]}
-        >
-          {link.label}
-        </a>
-      ))
-    }
-    <a href={makeHref(ROUTES.APP)} class="sp-nav-cta sp-mobile-cta">Try it free</a>
-    <a href={GITHUB_URL} target="_blank" rel="noopener noreferrer" class="sp-mobile-link">
-      GitHub
-    </a>
+    <div class="sp-mobile-panel-inner">
+      {
+        NAV_LINKS.map((link) => (
+          <a
+            href={makeHref(link.path)}
+            class:list={["sp-mobile-link", { "sp-mobile-link-active": currentPath === link.path }]}
+          >
+            {link.label}
+          </a>
+        ))
+      }
+      <a href={makeHref(ROUTES.APP)} class="sp-nav-cta sp-mobile-cta">Try it free</a>
+      <a href={GITHUB_URL} target="_blank" rel="noopener noreferrer" class="sp-mobile-link">
+        GitHub
+      </a>
+    </div>
   </div>
 </header>
 
@@ -100,6 +103,15 @@ function makeHref(path: string): string {
     backdrop-filter: blur(16px);
     -webkit-backdrop-filter: blur(16px);
     border-bottom: 1px solid var(--sp-border-light);
+    transition:
+      box-shadow 0.3s ease,
+      border-bottom-color 0.3s ease;
+  }
+
+  /* Scrolled state — enhanced shadow and border */
+  .sp-header.scrolled {
+    box-shadow: 0 2px 20px rgba(30, 27, 75, 0.08);
+    border-bottom-color: var(--sp-border);
   }
 
   .sp-header-inner {
@@ -120,6 +132,11 @@ function makeHref(path: string): string {
     font-weight: 700;
     color: var(--sp-text);
     text-decoration: none;
+    transition: opacity 0.2s;
+  }
+
+  .sp-logo:hover {
+    opacity: 0.8;
   }
 
   .sp-logo-dot {
@@ -128,6 +145,11 @@ function makeHref(path: string): string {
     border-radius: 50%;
     background: var(--sp-coral);
     flex-shrink: 0;
+    transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+  }
+
+  .sp-logo:hover .sp-logo-dot {
+    transform: scale(1.4);
   }
 
   .sp-nav-desktop {
@@ -143,7 +165,8 @@ function makeHref(path: string): string {
     text-decoration: none;
     padding: 0.45rem 0.85rem;
     border-radius: var(--sp-radius-full);
-    transition: all 0.2s;
+    transition: all 0.2s ease;
+    position: relative;
   }
 
   .sp-nav-link:hover {
@@ -151,9 +174,23 @@ function makeHref(path: string): string {
     background: var(--sp-border-light);
   }
 
+  /* Active indicator — animated underline pill */
   .sp-nav-link-active {
     color: var(--sp-text);
     font-weight: 600;
+    background: var(--sp-border-light);
+  }
+
+  .sp-nav-link-active::after {
+    content: "";
+    position: absolute;
+    bottom: 4px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 16px;
+    height: 2px;
+    background: var(--sp-coral);
+    border-radius: 2px;
   }
 
   .sp-nav-cta {
@@ -164,11 +201,12 @@ function makeHref(path: string): string {
     padding: 0.45rem 1.1rem;
     border-radius: var(--sp-radius-full);
     background: var(--sp-text);
-    transition: all 0.2s;
+    transition: all 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
   }
 
   .sp-nav-cta:hover {
     background: var(--sp-lavender-dark);
+    transform: translateY(-1px) scale(1.03);
   }
 
   .sp-nav-github {
@@ -187,17 +225,49 @@ function makeHref(path: string): string {
     padding: 0.25rem;
   }
 
-  /* Mobile panel — hidden by default */
+  /* Hamburger X animation */
+  .ham-line-1,
+  .ham-line-2,
+  .ham-line-3 {
+    transition:
+      transform 0.25s ease,
+      opacity 0.25s ease;
+    transform-origin: center;
+  }
+
+  .sp-hamburger[aria-expanded="true"] .ham-line-1 {
+    transform: translateY(6px) rotate(45deg);
+  }
+
+  .sp-hamburger[aria-expanded="true"] .ham-line-2 {
+    opacity: 0;
+    transform: scaleX(0);
+  }
+
+  .sp-hamburger[aria-expanded="true"] .ham-line-3 {
+    transform: translateY(-6px) rotate(-45deg);
+  }
+
+  /* Mobile panel — slide animation via max-height + overflow */
   .sp-mobile-panel {
-    display: none;
-    flex-direction: column;
-    gap: 0.25rem;
-    padding: 0.5rem 2rem 1.5rem;
-    border-bottom: 1px solid var(--sp-border-light);
+    max-height: 0;
+    overflow: hidden;
+    transition:
+      max-height 0.35s cubic-bezier(0.22, 1, 0.36, 1),
+      border-bottom-color 0.35s ease;
+    border-bottom: 1px solid transparent;
   }
 
   .sp-mobile-panel.sp-mobile-open {
+    max-height: 400px;
+    border-bottom-color: var(--sp-border-light);
+  }
+
+  .sp-mobile-panel-inner {
     display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    padding: 0.5rem 2rem 1.5rem;
   }
 
   .sp-mobile-link {
@@ -207,6 +277,7 @@ function makeHref(path: string): string {
     text-decoration: none;
     padding: 0.6rem 0;
     transition: color 0.2s;
+    border-bottom: 1px solid transparent;
   }
 
   .sp-mobile-link:hover {
@@ -214,7 +285,7 @@ function makeHref(path: string): string {
   }
 
   .sp-mobile-link-active {
-    color: var(--sp-text);
+    color: var(--sp-coral);
     font-weight: 600;
   }
 
@@ -232,10 +303,6 @@ function makeHref(path: string): string {
     .sp-hamburger {
       display: flex;
     }
-
-    .sp-mobile-panel.sp-mobile-open {
-      display: flex;
-    }
   }
 </style>
 
@@ -251,5 +318,19 @@ function makeHref(path: string): string {
     });
   }
 
-  document.addEventListener("astro:page-load", initMobileMenu);
+  function initHeaderScroll() {
+    const header = document.getElementById("sp-header");
+    if (!header) return;
+
+    const update = () => {
+      header.classList.toggle("scrolled", window.scrollY > 8);
+    };
+    update();
+    window.addEventListener("scroll", update, { passive: true });
+  }
+
+  document.addEventListener("astro:page-load", () => {
+    initMobileMenu();
+    initHeaderScroll();
+  });
 </script>

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -21,6 +21,7 @@ export const ROUTES = {
   BLOG: "/blog",
   ABOUT: "/about",
   FAQ: "/faq",
+  CHANGELOG: "/changelog",
 } as const;
 
 // Header navigation links
@@ -28,5 +29,6 @@ export const NAV_LINKS = [
   { label: "Home", path: ROUTES.HOME },
   { label: "Features", path: ROUTES.FEATURES },
   { label: "Blog", path: ROUTES.BLOG },
+  { label: "Changelog", path: ROUTES.CHANGELOG },
   { label: "About", path: ROUTES.ABOUT },
 ] as const;

--- a/src/config/ogData.ts
+++ b/src/config/ogData.ts
@@ -46,4 +46,9 @@ export const ogPageData: Record<string, OgPageData> = {
     description: "Guides and articles on image formats, compression, and web performance.",
     label: "Blog",
   },
+  changelog: {
+    title: "Changelog",
+    description: "A full history of updates, improvements, and new features in Reshrimp.",
+    label: "Changelog",
+  },
 };

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -13,4 +13,15 @@ const blog = defineCollection({
   }),
 });
 
-export const collections = { blog };
+const changelog = defineCollection({
+  loader: glob({ pattern: "**/*.md", base: "./src/content/changelog" }),
+  schema: z.object({
+    version: z.string(),
+    date: z.coerce.date(),
+    title: z.string(),
+    summary: z.string(),
+    type: z.enum(["major", "minor", "patch"]).default("patch"),
+  }),
+});
+
+export const collections = { blog, changelog };

--- a/src/content/changelog/v1.0.0.md
+++ b/src/content/changelog/v1.0.0.md
@@ -1,0 +1,28 @@
+---
+version: "1.0.0"
+date: 2026-02-25
+title: "Initial public release"
+summary: "Reshrimp launches with core image processing, background removal, and a fully private client-side architecture."
+type: "major"
+---
+
+## Added
+
+- **Image resizing** — Scale images to exact pixel dimensions with optional aspect ratio lock. Set width, height, or both.
+- **Format conversion** — Convert between JPEG, PNG, and WebP using the browser's native Canvas API.
+- **Smart compression** — Fine-tune quality from 0–100% with a live slider. See file size changes before downloading.
+- **Background removal** — One-click AI-powered background removal via `@imgly/background-removal`, running entirely in-browser using WebAssembly.
+- **Before/after preview** — Side-by-side tab view to compare the original and processed image, with full metadata display (dimensions, format, file size).
+- **Drag-and-drop upload** — Drop images directly onto the upload area or click to browse. Supports JPEG, PNG, WebP, and GIF.
+- **Privacy-first architecture** — Zero network requests for image data. All processing uses the Canvas API and runs locally.
+- **Offline support** — Works without an internet connection after the first page load.
+- **Open Graph image generation** — Dynamic per-page OG images generated at build time using Satori and `@resvg/resvg-js`.
+- **Blog** — Launch blog with three articles covering image compression, format comparisons, and client-side processing.
+- **FAQ page** — Answers to the most common questions about Reshrimp and browser-based image tools.
+
+## Technical
+
+- Built with Astro 5, Solid.js, TypeScript (strict mode), and Tailwind CSS v4.
+- Vitest test suite covering image service, validation, and canvas utilities.
+- Pre-commit hooks with lint-staged, commitlint, and Husky.
+- Sitemap generation and SEO metadata on all pages.

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -70,3 +70,54 @@ const ogImage = new URL(ogImagePath ?? deriveOgImagePath(Astro.url.pathname), As
     <slot />
   </body>
 </html>
+
+<script>
+  // ── Scroll reveal via Intersection Observer ──────────────────────────
+  function initReveal() {
+    const els = document.querySelectorAll<HTMLElement>("[data-reveal]");
+    if (!els.length) return;
+
+    // Apply staggered delays from data-reveal-delay attribute
+    els.forEach((el) => {
+      const delay = el.dataset.revealDelay;
+      if (delay) el.style.transitionDelay = `${delay}ms`;
+    });
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            (entry.target as HTMLElement).classList.add("revealed");
+            observer.unobserve(entry.target);
+          }
+        });
+      },
+      { threshold: 0.1, rootMargin: "0px 0px -40px 0px" }
+    );
+
+    els.forEach((el) => observer.observe(el));
+  }
+
+  // ── Button ripple effect ─────────────────────────────────────────────
+  function initRipple() {
+    document.addEventListener("pointerdown", (e) => {
+      const target = e.target as HTMLElement;
+      const btn = target.closest<HTMLElement>(".cta-pop, .sp-process-btn, .download-btn");
+      if (!btn || btn.hasAttribute("disabled")) return;
+
+      const ripple = document.createElement("span");
+      ripple.className = "sp-ripple";
+      const rect = btn.getBoundingClientRect();
+      ripple.style.left = `${e.clientX - rect.left}px`;
+      ripple.style.top = `${e.clientY - rect.top}px`;
+      btn.appendChild(ripple);
+      ripple.addEventListener("animationend", () => ripple.remove());
+    });
+  }
+
+  // Re-run on every SPA navigation
+  document.addEventListener("astro:page-load", () => {
+    initReveal();
+    initRipple();
+  });
+</script>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -34,7 +34,7 @@ function makeHref(path: string): string {
       <section class="about-content">
         <div class="about-container">
           <!-- Story -->
-          <div class="about-card">
+          <div class="about-card" data-reveal data-reveal-delay="0">
             <h2 class="about-card-title">The story</h2>
             <p>
               Most online image tools require uploading your photos to someone else's server. That
@@ -50,7 +50,7 @@ function makeHref(path: string): string {
           </div>
 
           <!-- Tech stack -->
-          <div class="about-card">
+          <div class="about-card" data-reveal data-reveal-delay="100">
             <h2 class="about-card-title">Tech stack</h2>
             <div class="about-tech-grid">
               <div class="about-tech-item">
@@ -81,7 +81,7 @@ function makeHref(path: string): string {
           </div>
 
           <!-- Contributing -->
-          <div class="about-card">
+          <div class="about-card" data-reveal data-reveal-delay="200">
             <h2 class="about-card-title">Contributing</h2>
             <p>
               Reshrimp is open source under the MIT license. Contributions of all kinds are welcome

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -41,7 +41,9 @@ const { Content } = await render(post);
                 ))
               }
             </div>
-            <h1 class="blog-article-title">{post.data.title}</h1>
+            <h1 class="blog-article-title" transition:name={`blog-title-${post.id}`}>
+              {post.data.title}
+            </h1>
             <div class="blog-article-meta">
               <time datetime={post.data.publishDate.toISOString()}>
                 {

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -39,15 +39,22 @@ const posts = (await getCollection("blog"))
         <div class="blog-container">
           <div class="blog-grid">
             {
-              posts.map((post) => (
-                <a href={makeHref(`${ROUTES.BLOG}/${post.id}`)} class="blog-card">
+              posts.map((post, i) => (
+                <a
+                  href={makeHref(`${ROUTES.BLOG}/${post.id}`)}
+                  class="blog-card"
+                  data-reveal
+                  data-reveal-delay={i * 80}
+                >
                   <div class="blog-card-inner">
                     <div class="blog-card-tags">
                       {post.data.tags.map((tag) => (
                         <span class="pop-chip pop-chip-lavender">{tag}</span>
                       ))}
                     </div>
-                    <h2 class="blog-card-title">{post.data.title}</h2>
+                    <h2 class="blog-card-title" transition:name={`blog-title-${post.id}`}>
+                      {post.data.title}
+                    </h2>
                     <p class="blog-card-desc">{post.data.description}</p>
                     <div class="blog-card-meta">
                       <time datetime={post.data.publishDate.toISOString()}>

--- a/src/pages/changelog/index.astro
+++ b/src/pages/changelog/index.astro
@@ -1,0 +1,317 @@
+---
+import { getCollection, render } from "astro:content";
+import Layout from "../../layouts/Layout.astro";
+import Header from "../../components/shared/Header.astro";
+import Footer from "../../components/shared/Footer.astro";
+import FloatingShapes from "../../components/shared/FloatingShapes.astro";
+
+const entries = (await getCollection("changelog")).sort(
+  (a, b) => b.data.date.valueOf() - a.data.date.valueOf()
+);
+
+const rendered = await Promise.all(
+  entries.map(async (entry) => {
+    const { Content } = await render(entry);
+    return { entry, Content };
+  })
+);
+
+const typeConfig = {
+  major: { label: "Major", class: "badge-major" },
+  minor: { label: "Minor", class: "badge-minor" },
+  patch: { label: "Patch", class: "badge-patch" },
+};
+---
+
+<Layout
+  title="Reshrimp — Changelog"
+  description="A full history of updates, improvements, and new features in Reshrimp."
+>
+  <div class="page-pop">
+    <FloatingShapes />
+    <Header currentPath="/changelog" />
+
+    <main transition:animate="fade">
+      <section class="cl-hero">
+        <div class="cl-container">
+          <span class="pop-chip pop-chip-mint">Changelog</span>
+          <h1 class="cl-title">What's new in Reshrimp</h1>
+          <p class="cl-subtitle">Every update, improvement, and fix — documented as it ships.</p>
+        </div>
+      </section>
+
+      <section class="cl-timeline-section">
+        <div class="cl-container">
+          <div class="cl-timeline">
+            {
+              rendered.map(({ entry, Content }, i) => {
+                const badge = typeConfig[entry.data.type];
+                return (
+                  <div class="cl-entry" data-reveal data-reveal-delay={i * 80}>
+                    <div class="cl-entry-aside">
+                      <div class="cl-version-badge">
+                        <span class="cl-version">v{entry.data.version}</span>
+                        <span class:list={["cl-type-badge", badge.class]}>{badge.label}</span>
+                      </div>
+                      <time class="cl-date" datetime={entry.data.date.toISOString()}>
+                        {entry.data.date.toLocaleDateString("en-US", {
+                          year: "numeric",
+                          month: "long",
+                          day: "numeric",
+                        })}
+                      </time>
+                    </div>
+
+                    <div class="cl-entry-connector">
+                      <div class="cl-dot" />
+                      {i < rendered.length - 1 && <div class="cl-line" />}
+                    </div>
+
+                    <div class="cl-entry-body">
+                      <div class="cl-entry-header">
+                        <h2 class="cl-entry-title">{entry.data.title}</h2>
+                        <p class="cl-entry-summary">{entry.data.summary}</p>
+                      </div>
+                      <div class="prose-sp cl-prose">
+                        <Content />
+                      </div>
+                    </div>
+                  </div>
+                );
+              })
+            }
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <Footer />
+  </div>
+</Layout>
+
+<style>
+  .page-pop {
+    position: relative;
+    overflow-x: hidden;
+    min-height: 100vh;
+  }
+
+  /* Hero */
+  .cl-hero {
+    padding: 5rem 2rem 3rem;
+    text-align: center;
+    position: relative;
+    z-index: 1;
+  }
+
+  .cl-container {
+    max-width: 900px;
+    margin: 0 auto;
+  }
+
+  .cl-title {
+    font-family: var(--sp-font-display);
+    font-size: clamp(2rem, 5vw, 3rem);
+    font-weight: 800;
+    line-height: 1.15;
+    margin: 1rem 0 1.25rem;
+    letter-spacing: -0.03em;
+  }
+
+  .cl-subtitle {
+    font-size: 1.05rem;
+    color: var(--sp-text-muted);
+    line-height: 1.7;
+    margin: 0;
+  }
+
+  /* Timeline */
+  .cl-timeline-section {
+    padding: 2rem 2rem 6rem;
+    position: relative;
+    z-index: 1;
+  }
+
+  .cl-timeline {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+  }
+
+  .cl-entry {
+    display: grid;
+    grid-template-columns: 200px 32px 1fr;
+    gap: 0 1.5rem;
+    position: relative;
+  }
+
+  /* Aside — version + date */
+  .cl-entry-aside {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    padding-top: 0.25rem;
+    gap: 0.35rem;
+    padding-bottom: 3rem;
+  }
+
+  .cl-version-badge {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+
+  .cl-version {
+    font-family: var(--sp-font-display);
+    font-size: 1.1rem;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    color: var(--sp-text);
+  }
+
+  .cl-type-badge {
+    font-size: 0.65rem;
+    font-weight: 700;
+    padding: 0.2rem 0.55rem;
+    border-radius: var(--sp-radius-full);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .badge-major {
+    background: var(--sp-coral-light);
+    color: var(--sp-coral-dark);
+  }
+
+  .badge-minor {
+    background: var(--sp-mint-light);
+    color: var(--sp-mint-dark);
+  }
+
+  .badge-patch {
+    background: var(--sp-lavender-light);
+    color: var(--sp-lavender-dark);
+  }
+
+  .cl-date {
+    font-size: 0.78rem;
+    color: var(--sp-text-soft);
+  }
+
+  /* Connector — dot + vertical line */
+  .cl-entry-connector {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    flex-shrink: 0;
+  }
+
+  .cl-dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: var(--sp-coral);
+    border: 2px solid var(--sp-bg);
+    outline: 2px solid var(--sp-coral);
+    margin-top: 0.35rem;
+    flex-shrink: 0;
+    z-index: 1;
+  }
+
+  .cl-line {
+    width: 2px;
+    flex: 1;
+    background: var(--sp-border);
+    margin-top: 4px;
+  }
+
+  /* Entry body */
+  .cl-entry-body {
+    padding-bottom: 3rem;
+  }
+
+  .cl-entry-header {
+    margin-bottom: 1.25rem;
+  }
+
+  .cl-entry-title {
+    font-family: var(--sp-font-display);
+    font-size: 1.25rem;
+    font-weight: 700;
+    margin: 0 0 0.4rem;
+    letter-spacing: -0.02em;
+    line-height: 1.3;
+  }
+
+  .cl-entry-summary {
+    font-size: 0.9rem;
+    color: var(--sp-text-muted);
+    line-height: 1.6;
+    margin: 0;
+  }
+
+  /* Scoped prose overrides for changelog */
+  .cl-prose {
+    font-size: 0.9rem;
+    line-height: 1.7;
+    background: var(--sp-bg-card);
+    border: 1px solid var(--sp-border);
+    border-radius: var(--sp-radius-lg);
+    padding: 1.5rem;
+    box-shadow: var(--sp-shadow);
+  }
+
+  .cl-prose :global(h2) {
+    font-size: 0.75rem !important;
+    font-weight: 700 !important;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--sp-text-muted);
+    margin-top: 1.25rem !important;
+    margin-bottom: 0.5rem !important;
+  }
+
+  .cl-prose :global(h2:first-child) {
+    margin-top: 0 !important;
+  }
+
+  .cl-prose :global(ul) {
+    padding-left: 1.25rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .cl-prose :global(li) {
+    margin-bottom: 0.3rem;
+    font-size: 0.88rem;
+    color: var(--sp-text);
+  }
+
+  .cl-prose :global(strong) {
+    color: var(--sp-text);
+    font-weight: 600;
+  }
+
+  /* Responsive */
+  @media (max-width: 640px) {
+    .cl-entry {
+      grid-template-columns: 1fr;
+      grid-template-rows: auto auto auto;
+    }
+
+    .cl-entry-aside {
+      flex-direction: row;
+      align-items: center;
+      padding-bottom: 0.75rem;
+      grid-row: 1;
+    }
+
+    .cl-entry-connector {
+      display: none;
+    }
+
+    .cl-entry-body {
+      grid-row: 2;
+      padding-bottom: 2.5rem;
+    }
+  }
+</style>

--- a/src/pages/features.astro
+++ b/src/pages/features.astro
@@ -86,7 +86,11 @@ const features = [
         <div class="features-list-container">
           {
             features.map((feature, i) => (
-              <div class:list={["feature-row", { "feature-row-reverse": i % 2 === 1 }]}>
+              <div
+                class:list={["feature-row", { "feature-row-reverse": i % 2 === 1 }]}
+                data-reveal
+                data-reveal-delay={i * 80}
+              >
                 <div class={`feature-icon-box feature-icon-${feature.color}`}>
                   <feature.icon
                     size={40}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -83,7 +83,7 @@ const jsonLd = {
         <div class="bento-pop-container">
           <SectionHeader label="What can you do?" title="Everything you need. Nothing you don't." />
           <div class="bento-grid">
-            <div class="bento-card bento-card-lg bento-coral">
+            <div class="bento-card bento-card-lg bento-coral" data-reveal data-reveal-delay="0">
               <div class="bento-card-content">
                 <Scaling size={32} strokeWidth={1.75} class="bento-icon" />
                 <h3 class="bento-title">Resize with precision</h3>
@@ -93,7 +93,7 @@ const jsonLd = {
                 </p>
               </div>
             </div>
-            <div class="bento-card bento-mint">
+            <div class="bento-card bento-mint" data-reveal data-reveal-delay="80">
               <div class="bento-card-content">
                 <ArrowLeftRight size={32} strokeWidth={1.75} class="bento-icon" />
                 <h3 class="bento-title">Convert formats</h3>
@@ -103,7 +103,7 @@ const jsonLd = {
                 </p>
               </div>
             </div>
-            <div class="bento-card bento-lavender">
+            <div class="bento-card bento-lavender" data-reveal data-reveal-delay="160">
               <div class="bento-card-content">
                 <Gauge size={32} strokeWidth={1.75} class="bento-icon" />
                 <h3 class="bento-title">Compress smartly</h3>
@@ -113,7 +113,7 @@ const jsonLd = {
                 </p>
               </div>
             </div>
-            <div class="bento-card bento-card-lg bento-yellow">
+            <div class="bento-card bento-card-lg bento-yellow" data-reveal data-reveal-delay="240">
               <div class="bento-card-content">
                 <ShieldCheck size={32} strokeWidth={1.75} class="bento-icon" />
                 <h3 class="bento-title">Completely private</h3>
@@ -132,7 +132,7 @@ const jsonLd = {
         <div class="how-pop-container">
           <SectionHeader label="Dead simple" title="Three steps. Seriously." />
           <div class="how-pop-steps">
-            <div class="how-pop-step">
+            <div class="how-pop-step" data-reveal data-reveal-delay="0">
               <div class="how-pop-num-wrap how-pop-num-coral">
                 <span class="how-pop-num">1</span>
               </div>
@@ -141,7 +141,7 @@ const jsonLd = {
                 Drag and drop or click to browse. Supports JPEG, PNG, WebP, and GIF.
               </p>
             </div>
-            <div class="how-pop-connector">
+            <div class="how-pop-connector" data-reveal data-reveal-delay="100">
               <svg width="40" height="24" viewBox="0 0 40 24" fill="none">
                 <path
                   d="M0 12h36M30 6l6 6-6 6"
@@ -152,7 +152,7 @@ const jsonLd = {
                   opacity="0.3"></path>
               </svg>
             </div>
-            <div class="how-pop-step">
+            <div class="how-pop-step" data-reveal data-reveal-delay="200">
               <div class="how-pop-num-wrap how-pop-num-mint">
                 <span class="how-pop-num">2</span>
               </div>
@@ -161,7 +161,7 @@ const jsonLd = {
                 Set dimensions, pick a format, adjust quality. Preview updates live.
               </p>
             </div>
-            <div class="how-pop-connector">
+            <div class="how-pop-connector" data-reveal data-reveal-delay="300">
               <svg width="40" height="24" viewBox="0 0 40 24" fill="none">
                 <path
                   d="M0 12h36M30 6l6 6-6 6"
@@ -172,7 +172,7 @@ const jsonLd = {
                   opacity="0.3"></path>
               </svg>
             </div>
-            <div class="how-pop-step">
+            <div class="how-pop-step" data-reveal data-reveal-delay="400">
               <div class="how-pop-num-wrap how-pop-num-lavender">
                 <span class="how-pop-num">3</span>
               </div>
@@ -188,7 +188,7 @@ const jsonLd = {
       <!-- Trust banner -->
       <section class="trust-pop">
         <div class="trust-pop-container">
-          <div class="trust-pop-card">
+          <div class="trust-pop-card" data-reveal>
             <div class="trust-pop-icon">
               <svg
                 width="36"

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -111,6 +111,69 @@ body {
   }
 }
 
+@keyframes revealUp {
+  from {
+    opacity: 0;
+    transform: translateY(28px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes rippleEffect {
+  to {
+    transform: scale(4);
+    opacity: 0;
+  }
+}
+
+/* ===== View Transitions — SPA page enter/exit ===== */
+@keyframes pageEnter {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes pageExit {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+}
+
+::view-transition-old(root) {
+  animation: pageExit 0.2s ease forwards;
+}
+
+::view-transition-new(root) {
+  animation: pageEnter 0.3s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+/* ===== Scroll Reveal ===== */
+[data-reveal] {
+  opacity: 0;
+  transform: translateY(28px) scale(0.98);
+  transition:
+    opacity 0.55s cubic-bezier(0.22, 1, 0.36, 1),
+    transform 0.55s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+[data-reveal].revealed {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+
 /* ===== CTA Buttons ===== */
 .cta-pop {
   display: inline-flex;
@@ -128,12 +191,27 @@ body {
   box-shadow: 0 4px 16px rgba(255, 107, 107, 0.3);
   border: none;
   cursor: pointer;
+  position: relative;
+  overflow: hidden;
 }
 
 .cta-pop:hover {
   background: var(--sp-coral-dark);
   transform: translateY(-2px) scale(1.02);
   box-shadow: 0 6px 24px rgba(255, 107, 107, 0.4);
+}
+
+/* Ripple element injected by JS */
+.sp-ripple {
+  position: absolute;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.35);
+  width: 40px;
+  height: 40px;
+  margin-top: -20px;
+  margin-left: -20px;
+  pointer-events: none;
+  animation: rippleEffect 0.55s ease-out forwards;
 }
 
 .cta-pop-arrow {
@@ -297,6 +375,8 @@ body {
   transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
   box-shadow: 0 4px 16px rgba(255, 107, 107, 0.3);
   margin-top: 0.5rem;
+  position: relative;
+  overflow: hidden;
 }
 
 .sp-process-btn:hover:not(:disabled) {
@@ -559,6 +639,8 @@ body {
   cursor: pointer;
   transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
   box-shadow: 0 4px 16px rgba(45, 212, 191, 0.3);
+  position: relative;
+  overflow: hidden;
 }
 
 .download-btn:hover:not(:disabled) {


### PR DESCRIPTION
Changelog:
- Add `changelog` content collection with version/date/type schema
- Create `/changelog` timeline page with version badges, dot-line
  connector layout, and inline rendered markdown per entry
- Add initial v1.0.0 entry documenting the launch feature set
- Register CHANGELOG route in constants, ogData, footer and nav

Animations:
- Custom view transition (slide-up enter / fade-out exit) overriding
  Astro's default fade via ::view-transition-* pseudo-elements
- Intersection Observer scroll-reveal for bento cards, how-it-works
  steps, trust banner, about cards, features rows, and blog cards —
  staggered via data-reveal-delay attributes
- Button ripple effect on cta-pop, sp-process-btn, download-btn via
  pointer-event injected .sp-ripple span
- Header scroll state: .scrolled class adds shadow + border depth
- Mobile menu slide animation via max-height transition (replaces
  display:none snap)
- Hamburger icon animates into an X on open (line rotate + fade)
- Nav active link indicator: coral underline pill + background pill
- Logo dot scales on hover via cubic-bezier spring
- Nav CTA button gets spring scale on hover
- Shared element transition:name on blog post titles for smooth
  card→article navigation

https://claude.ai/code/session_01HwxfVRuigpzTm4mqNBSJmR