### PR TITLE
feat: add resize units, custom select, and social media presets

### DIFF
--- a/src/components/app/ImageApp.tsx
+++ b/src/components/app/ImageApp.tsx
@@ -1,6 +1,6 @@
 import { createSignal, createMemo, createEffect, onCleanup, type Setter } from "solid-js";
 import type { ProcessedImage, ValidationResult, ImageFormat } from "@/types/image";
-import type { ProcessResult } from "@/types/processing";
+import type { ProcessResult, ResizeUnit } from "@/types/processing";
 import { processImage, getImageMetadata } from "@/services/imageService";
 import { validateImageFile, generateDownloadFilename } from "@/services/validationService";
 import {
@@ -9,7 +9,11 @@ import {
   generateId,
   calculateHeightFromWidth,
   calculateWidthFromHeight,
+  convertToPx,
+  convertFromPx,
 } from "@/utils/imageUtils";
+import { DEFAULT_DPI } from "@/config/constants";
+import { SOCIAL_MEDIA_PRESETS } from "@/config/presets";
 import UploadArea from "./UploadArea";
 import ProcessingControls from "./ProcessingControls";
 import PreviewPanel from "./PreviewPanel";
@@ -17,6 +21,13 @@ import PreviewPanel from "./PreviewPanel";
 export interface SizeDiff {
   text: string;
   className: string;
+}
+
+/** Format a display-unit value to a readable string (no trailing zeros). */
+function formatUnitValue(value: number, unit: ResizeUnit): string {
+  if (unit === "px") return String(Math.round(value));
+  // For non-px units show up to 2 decimal places, stripping trailing zeros
+  return parseFloat(value.toFixed(2)).toString();
 }
 
 export default function ImageApp() {
@@ -34,6 +45,7 @@ export default function ImageApp() {
   const [validation, setValidation] = createSignal<ValidationResult | null>(null);
   const [isDragOver, setIsDragOver] = createSignal(false);
   const [tooltipOpen, setTooltipOpen] = createSignal(false);
+  const [dpiTooltipOpen, setDpiTooltipOpen] = createSignal(false);
 
   // ── Form controls ─────────────────────────────────────────────────────────
   const [widthValue, setWidthValue] = createSignal("");
@@ -43,6 +55,11 @@ export default function ImageApp() {
   const [formatValue, setFormatValue] = createSignal("");
   const [previousFormatValue, setPreviousFormatValue] = createSignal("");
   const [qualityValue, setQualityValue] = createSignal(92);
+
+  // ── Resize unit controls ──────────────────────────────────────────────────
+  const [resizeUnit, setResizeUnit] = createSignal<ResizeUnit>("px");
+  const [dpiValue, setDpiValue] = createSignal(DEFAULT_DPI);
+  const [presetValue, setPresetValue] = createSignal("");
 
   // ── Object URL tracking for cleanup ──────────────────────────────────────
   const [objectUrls, setObjectUrls] = createSignal<string[]>([]);
@@ -68,12 +85,18 @@ export default function ImageApp() {
 
   const widthPlaceholder = createMemo(() => {
     const img = currentImage();
-    return img ? String(img.metadata.width) : "Original";
+    if (!img) return "Original";
+    const px = img.metadata.width;
+    const display = convertFromPx(px, resizeUnit(), px, dpiValue());
+    return formatUnitValue(display, resizeUnit());
   });
 
   const heightPlaceholder = createMemo(() => {
     const img = currentImage();
-    return img ? String(img.metadata.height) : "Original";
+    if (!img) return "Original";
+    const px = img.metadata.height;
+    const display = convertFromPx(px, resizeUnit(), px, dpiValue());
+    return formatUnitValue(display, resizeUnit());
   });
 
   const sizeDifference = createMemo<SizeDiff | null>(() => {
@@ -132,26 +155,42 @@ export default function ImageApp() {
       setPreviousFormatValue("");
       setQualityValue(92);
       setTooltipOpen(false);
+
+      // Reset unit controls
+      setResizeUnit("px");
+      setDpiValue(DEFAULT_DPI);
+      setPresetValue("");
+      setDpiTooltipOpen(false);
     } catch (err) {
       setError("Failed to load image. Please try another file.");
       console.error("Error loading image:", err);
     }
   }
 
+  /**
+   * Convert the current width/height display values to pixels,
+   * then trigger processImage with those px dimensions.
+   */
   async function handleProcess(): Promise<void> {
     const img = currentImage();
     if (!img || isProcessing()) return;
 
-    const widthNum = widthValue() ? parseInt(widthValue(), 10) : undefined;
-    const heightNum = heightValue() ? parseInt(heightValue(), 10) : undefined;
+    const unit = resizeUnit();
+    const dpi = dpiValue();
+
+    const wRaw = widthValue() ? parseFloat(widthValue()) : NaN;
+    const hRaw = heightValue() ? parseFloat(heightValue()) : NaN;
+
+    const widthPx = isNaN(wRaw) ? undefined : convertToPx(wRaw, unit, img.metadata.width, dpi);
+    const heightPx = isNaN(hRaw) ? undefined : convertToPx(hRaw, unit, img.metadata.height, dpi);
 
     const options = {
       removeBackground: removeBackground(),
-      ...(widthNum || heightNum
+      ...(widthPx || heightPx
         ? {
             resize: {
-              width: widthNum,
-              height: heightNum,
+              width: widthPx,
+              height: heightPx,
               maintainAspectRatio: maintainAspectRatio(),
             },
           }
@@ -181,7 +220,6 @@ export default function ImageApp() {
 
       const processedUrl = trackUrl(URL.createObjectURL(result.blob));
 
-      // Update the current image's processedUrl in place
       setCurrentImage((prev) => (prev ? { ...prev, processedUrl } : null));
       setProcessResult(result);
     } catch (err) {
@@ -222,33 +260,128 @@ export default function ImageApp() {
     setRemoveBackground(checked);
   }
 
-  function handleWidthInput(val: string): void {
-    setWidthValue(val);
-    if (maintainAspectRatio() && val) {
-      const img = currentImage();
-      if (img) {
-        const w = parseInt(val, 10);
+  /**
+   * Convert an existing display value between units.
+   * Returns the new display string, or "" if the input is empty/invalid.
+   */
+  function rebaseValue(
+    displayStr: string,
+    oldUnit: ResizeUnit,
+    newUnit: ResizeUnit,
+    originalPx: number,
+    dpi: number
+  ): string {
+    if (!displayStr) return "";
+    const num = parseFloat(displayStr);
+    if (isNaN(num)) return "";
+    const px = convertToPx(num, oldUnit, originalPx, dpi);
+    const newDisplay = convertFromPx(px, newUnit, originalPx, dpi);
+    return formatUnitValue(newDisplay, newUnit);
+  }
+
+  function handleUnitChange(newUnit: ResizeUnit): void {
+    const img = currentImage();
+    const oldUnit = resizeUnit();
+    const dpi = dpiValue();
+
+    if (img) {
+      setWidthValue(rebaseValue(widthValue(), oldUnit, newUnit, img.metadata.width, dpi));
+      setHeightValue(rebaseValue(heightValue(), oldUnit, newUnit, img.metadata.height, dpi));
+    }
+
+    setResizeUnit(newUnit);
+  }
+
+  function handleDpiChange(newDpi: number): void {
+    const img = currentImage();
+    const unit = resizeUnit();
+    const oldDpi = dpiValue();
+
+    // Only physical units are affected by DPI changes; % and px are invariant
+    if (img && (unit === "in" || unit === "cm")) {
+      // Convert display → px (old DPI) → display (new DPI)
+      if (widthValue()) {
+        const w = parseFloat(widthValue());
         if (!isNaN(w)) {
+          const px = convertToPx(w, unit, img.metadata.width, oldDpi);
+          setWidthValue(formatUnitValue(convertFromPx(px, unit, img.metadata.width, newDpi), unit));
+        }
+      }
+      if (heightValue()) {
+        const h = parseFloat(heightValue());
+        if (!isNaN(h)) {
+          const px = convertToPx(h, unit, img.metadata.height, oldDpi);
           setHeightValue(
-            String(calculateHeightFromWidth(img.metadata.width, img.metadata.height, w))
+            formatUnitValue(convertFromPx(px, unit, img.metadata.height, newDpi), unit)
           );
         }
       }
     }
+
+    setDpiValue(newDpi);
   }
 
-  function handleHeightInput(val: string): void {
-    setHeightValue(val);
+  function handlePresetChange(label: string): void {
+    setPresetValue(label);
+    if (!label) return; // "Custom" — don't touch W/H
+
+    const preset = SOCIAL_MEDIA_PRESETS.find((p) => p.label === label);
+    if (!preset) return;
+
+    // Presets are always in px — switch unit first, then set values atomically
+    // bypassing aspect-ratio linkage by setting both fields directly
+    setResizeUnit("px");
+    setWidthValue(String(preset.width));
+    setHeightValue(String(preset.height));
+  }
+
+  /**
+   * Aspect-ratio-aware width handler.
+   * Operates entirely in display units.
+   */
+  function handleWidthInput(val: string): void {
+    setWidthValue(val);
+    setPresetValue(""); // user edited manually → reset preset
+
     if (maintainAspectRatio() && val) {
       const img = currentImage();
-      if (img) {
-        const h = parseInt(val, 10);
-        if (!isNaN(h)) {
-          setWidthValue(
-            String(calculateWidthFromHeight(img.metadata.width, img.metadata.height, h))
-          );
-        }
-      }
+      if (!img) return;
+
+      const num = parseFloat(val);
+      if (isNaN(num)) return;
+
+      const unit = resizeUnit();
+      const dpi = dpiValue();
+
+      // Convert entered width to px, compute linked height in px, convert back
+      const wPx = convertToPx(num, unit, img.metadata.width, dpi);
+      const hPx = calculateHeightFromWidth(img.metadata.width, img.metadata.height, wPx);
+      setHeightValue(formatUnitValue(convertFromPx(hPx, unit, img.metadata.height, dpi), unit));
+    }
+  }
+
+  /**
+   * Aspect-ratio-aware height handler.
+   * Operates entirely in display units.
+   */
+  function handleHeightInput(val: string): void {
+    setHeightValue(val);
+    setPresetValue(""); // user edited manually → reset preset
+
+    if (maintainAspectRatio() && val) {
+      const img = currentImage();
+      if (!img) return;
+
+      const num = parseFloat(val);
+      if (isNaN(num)) return;
+
+      const unit = resizeUnit();
+      const dpi = dpiValue();
+
+      // Convert entered height to px, compute linked width in px, convert back
+      const hPx = convertToPx(num, unit, img.metadata.height, dpi);
+      const wPx = calculateWidthFromHeight(img.metadata.width, img.metadata.height, hPx);
+      setWidthValue(formatUnitValue(convertFromPx(wPx, unit, img.metadata.width, dpi), unit));
     }
   }
 
@@ -298,6 +431,14 @@ export default function ImageApp() {
           onProcess={handleProcess}
           widthPlaceholder={widthPlaceholder}
           heightPlaceholder={heightPlaceholder}
+          resizeUnit={resizeUnit}
+          onUnitChange={handleUnitChange}
+          dpiValue={dpiValue}
+          onDpiChange={handleDpiChange}
+          dpiTooltipOpen={dpiTooltipOpen}
+          setDpiTooltipOpen={setDpiTooltipOpen}
+          presetValue={presetValue}
+          onPresetChange={handlePresetChange}
         />
       </div>
       <PreviewPanel

--- a/src/components/app/ProcessingControls.tsx
+++ b/src/components/app/ProcessingControls.tsx
@@ -1,4 +1,8 @@
 import { Show, onMount, onCleanup, type Accessor, type Setter } from "solid-js";
+import type { ResizeUnit } from "@/types/processing";
+import { DPI_OPTIONS } from "@/config/constants";
+import { SOCIAL_MEDIA_PRESETS } from "@/config/presets";
+import AppSelect, { type AppSelectOption } from "@/components/shared/AppSelect";
 
 interface ProcessingControlsProps {
   controlsActive: Accessor<boolean>;
@@ -22,15 +26,59 @@ interface ProcessingControlsProps {
   onProcess: () => void;
   widthPlaceholder: Accessor<string>;
   heightPlaceholder: Accessor<string>;
+  // Resize unit
+  resizeUnit: Accessor<ResizeUnit>;
+  onUnitChange: (unit: ResizeUnit) => void;
+  // DPI (only relevant when unit is 'in' or 'cm')
+  dpiValue: Accessor<number>;
+  onDpiChange: (dpi: number) => void;
+  dpiTooltipOpen: Accessor<boolean>;
+  setDpiTooltipOpen: Setter<boolean>;
+  // Preset
+  presetValue: Accessor<string>;
+  onPresetChange: (label: string) => void;
 }
 
+const FORMAT_OPTIONS: AppSelectOption[] = [
+  { value: "", label: "Keep original" },
+  { value: "image/jpeg", label: "JPEG" },
+  { value: "image/png", label: "PNG" },
+  { value: "image/webp", label: "WebP" },
+];
+
+const PRESET_OPTIONS: AppSelectOption[] = [
+  { value: "", label: "Custom" },
+  ...SOCIAL_MEDIA_PRESETS.map((p) => ({ value: p.label, label: p.label })),
+];
+
+const UNIT_OPTIONS: AppSelectOption[] = [
+  { value: "px", label: "px" },
+  { value: "%", label: "%" },
+  { value: "in", label: "in" },
+  { value: "cm", label: "cm" },
+];
+
+const DPI_SELECT_OPTIONS: AppSelectOption[] = DPI_OPTIONS.map((d) => ({
+  value: String(d),
+  label: `${d} DPI`,
+}));
+
 export default function ProcessingControls(props: ProcessingControlsProps) {
-  // Close tooltip when clicking outside
+  // Close background-removal tooltip when clicking outside
   onMount(() => {
     const handler = () => props.setTooltipOpen(false);
     document.addEventListener("click", handler);
     onCleanup(() => document.removeEventListener("click", handler));
   });
+
+  // Close DPI tooltip when clicking outside
+  onMount(() => {
+    const handler = () => props.setDpiTooltipOpen(false);
+    document.addEventListener("click", handler);
+    onCleanup(() => document.removeEventListener("click", handler));
+  });
+
+  const showDpi = () => props.resizeUnit() === "in" || props.resizeUnit() === "cm";
 
   return (
     <div
@@ -43,6 +91,21 @@ export default function ProcessingControls(props: ProcessingControlsProps) {
         <h4 class="text-[0.8rem] font-semibold text-sp-text m-0 uppercase tracking-wider">
           Resize
         </h4>
+
+        {/* Presets */}
+        <div>
+          <span class="block text-[0.8rem] text-sp-text-muted mb-1">Preset</span>
+          <AppSelect
+            id="preset-select"
+            options={PRESET_OPTIONS}
+            value={props.presetValue()}
+            onChange={props.onPresetChange}
+            disabled={!props.controlsActive()}
+            placeholder="Custom"
+          />
+        </div>
+
+        {/* Width / Height inputs */}
         <div class="grid grid-cols-2 gap-3">
           <label class="block">
             <span class="block text-[0.8rem] text-sp-text-muted mb-1">Width</span>
@@ -50,8 +113,9 @@ export default function ProcessingControls(props: ProcessingControlsProps) {
               type="number"
               id="width-input"
               class="w-full px-3 py-2 border border-sp-border rounded-sp font-body text-[0.85rem] text-sp-text bg-sp-bg transition-[border-color,box-shadow] duration-200 focus:outline-none focus:border-sp-lavender focus:shadow-[0_0_0_3px_rgba(167,139,250,0.15)]"
-              min="1"
-              max="10000"
+              min="0.001"
+              max="100000"
+              step="any"
               placeholder={props.widthPlaceholder()}
               disabled={!props.controlsActive()}
               value={props.widthValue()}
@@ -64,8 +128,9 @@ export default function ProcessingControls(props: ProcessingControlsProps) {
               type="number"
               id="height-input"
               class="w-full px-3 py-2 border border-sp-border rounded-sp font-body text-[0.85rem] text-sp-text bg-sp-bg transition-[border-color,box-shadow] duration-200 focus:outline-none focus:border-sp-lavender focus:shadow-[0_0_0_3px_rgba(167,139,250,0.15)]"
-              min="1"
-              max="10000"
+              min="0.001"
+              max="100000"
+              step="any"
               placeholder={props.heightPlaceholder()}
               disabled={!props.controlsActive()}
               value={props.heightValue()}
@@ -73,6 +138,73 @@ export default function ProcessingControls(props: ProcessingControlsProps) {
             />
           </label>
         </div>
+
+        {/* Unit selector */}
+        <div>
+          <span class="block text-[0.8rem] text-sp-text-muted mb-1">Unit</span>
+          <AppSelect
+            id="unit-select"
+            options={UNIT_OPTIONS}
+            value={props.resizeUnit()}
+            onChange={(v) => props.onUnitChange(v as ResizeUnit)}
+            disabled={!props.controlsActive()}
+          />
+        </div>
+
+        {/* DPI selector — only shown for physical units */}
+        <Show when={showDpi()}>
+          <div>
+            <div class="flex items-center gap-1.5 mb-1">
+              <span class="text-[0.8rem] text-sp-text-muted">Resolution</span>
+              <span id="dpi-info-tip" class="relative">
+                <button
+                  type="button"
+                  id="dpi-info-icon"
+                  class="info-icon"
+                  aria-label="DPI info"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    props.setDpiTooltipOpen((v) => !v);
+                  }}
+                >
+                  <svg
+                    width="14"
+                    height="14"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    aria-hidden="true"
+                  >
+                    <circle cx="12" cy="12" r="10" />
+                    <line x1="12" y1="16" x2="12" y2="12" />
+                    <line x1="12" y1="8" x2="12.01" y2="8" />
+                  </svg>
+                </button>
+                <span
+                  id="dpi-tooltip"
+                  class="info-tooltip"
+                  classList={{ active: props.dpiTooltipOpen() }}
+                  role="tooltip"
+                >
+                  DPI (dots per inch) sets how many pixels map to one inch. Use <strong>96</strong>{" "}
+                  for screen or digital exports, <strong>300</strong> for print-quality output.
+                </span>
+              </span>
+            </div>
+            <AppSelect
+              id="dpi-select"
+              options={DPI_SELECT_OPTIONS}
+              value={String(props.dpiValue())}
+              onChange={(v) => props.onDpiChange(Number(v))}
+              disabled={!props.controlsActive()}
+            />
+          </div>
+        </Show>
+
+        {/* Aspect ratio lock */}
         <label class="flex items-center gap-2 text-[0.8rem] text-sp-text-muted cursor-pointer">
           <input
             type="checkbox"
@@ -117,7 +249,6 @@ export default function ProcessingControls(props: ProcessingControlsProps) {
                   props.setTooltipOpen((v) => !v);
                 }}
               >
-                {/* Info icon — inlined SVG (lucide "info") */}
                 <svg
                   width="14"
                   height="14"
@@ -153,37 +284,14 @@ export default function ProcessingControls(props: ProcessingControlsProps) {
         <h4 class="text-[0.8rem] font-semibold text-sp-text m-0 uppercase tracking-wider">
           Format
         </h4>
-        <div class="relative">
-          <select
-            id="format-select"
-            class="w-full py-2 pl-3 pr-9 border border-sp-border rounded-sp font-body text-[0.85rem] text-sp-text bg-sp-bg appearance-none transition-[border-color,box-shadow] duration-200 cursor-pointer focus:outline-none focus:border-sp-lavender focus:shadow-[0_0_0_3px_rgba(167,139,250,0.15)]"
-            classList={{ "sp-select-disabled": props.formatSelectDisabled() }}
-            disabled={!props.controlsActive() || props.formatSelectDisabled()}
-            value={props.formatValue()}
-            onChange={(e) => props.setFormatValue((e.target as HTMLSelectElement).value)}
-          >
-            <option value="">Keep original</option>
-            <option value="image/jpeg">JPEG</option>
-            <option value="image/png">PNG</option>
-            <option value="image/webp">WebP</option>
-          </select>
-          <svg
-            class="absolute right-3 top-1/2 -translate-y-1/2 text-sp-lavender pointer-events-none transition-transform duration-200"
-            width="12"
-            height="12"
-            viewBox="0 0 12 12"
-            fill="none"
-            stroke="currentColor"
-            aria-hidden="true"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M3 4.5l3 3 3-3"
-            />
-          </svg>
-        </div>
+        <AppSelect
+          id="format-select"
+          options={FORMAT_OPTIONS}
+          value={props.formatValue()}
+          onChange={(v) => props.setFormatValue(v)}
+          disabled={!props.controlsActive() || props.formatSelectDisabled()}
+          placeholder="Keep original"
+        />
       </div>
 
       {/* Quality */}

--- a/src/components/shared/AppSelect.tsx
+++ b/src/components/shared/AppSelect.tsx
@@ -26,7 +26,10 @@ export interface AppSelectProps {
 }
 
 interface DropdownPos {
-  top: number;
+  /** Set for downward-opening dropdowns (viewport px from top). */
+  top?: number;
+  /** Set for upward-opening dropdowns (viewport px from bottom). */
+  bottom?: number;
   left: number;
   width: number;
   openUpward: boolean;
@@ -43,7 +46,6 @@ export default function AppSelect(props: AppSelectProps) {
   const [open, setOpen] = createSignal(false);
   const [focusedIndex, setFocusedIndex] = createSignal(-1);
   const [pos, setPos] = createSignal<DropdownPos>({
-    top: 0,
     left: 0,
     width: 0,
     openUpward: false,
@@ -58,17 +60,17 @@ export default function AppSelect(props: AppSelectProps) {
 
   // ── Position calculation ────────────────────────────────────────────────
   function calcPos(): DropdownPos {
-    if (!triggerRef) return { top: 0, left: 0, width: 0, openUpward: false };
+    if (!triggerRef) return { left: 0, width: 0, openUpward: false };
     const r = triggerRef.getBoundingClientRect();
     const dropdownMaxH = 240;
     const spaceBelow = window.innerHeight - r.bottom;
     const openUpward = spaceBelow < dropdownMaxH && r.top > dropdownMaxH;
-    return {
-      top: openUpward ? r.top + window.scrollY - dropdownMaxH - 4 : r.bottom + window.scrollY + 4,
-      left: r.left + window.scrollX,
-      width: r.width,
-      openUpward,
-    };
+    // Use position:fixed viewport coordinates — no scrollY/scrollX needed.
+    // For upward openings anchor via `bottom` so the dropdown bottom always
+    // sits flush with the trigger top regardless of actual dropdown height.
+    return openUpward
+      ? { bottom: window.innerHeight - r.top + 4, left: r.left, width: r.width, openUpward: true }
+      : { top: r.bottom + 4, left: r.left, width: r.width, openUpward: false };
   }
 
   // ── Open / close ─────────────────────────────────────────────────────────
@@ -236,8 +238,9 @@ export default function AppSelect(props: AppSelectProps) {
             class="sp-select-listbox"
             classList={{ "sp-select-listbox-upward": pos().openUpward }}
             style={{
-              position: "absolute",
-              top: `${pos().top}px`,
+              position: "fixed",
+              top: pos().top !== undefined ? `${pos().top}px` : "auto",
+              bottom: pos().bottom !== undefined ? `${pos().bottom}px` : "auto",
               left: `${pos().left}px`,
               width: `${pos().width}px`,
               "z-index": "9999",

--- a/src/components/shared/AppSelect.tsx
+++ b/src/components/shared/AppSelect.tsx
@@ -1,0 +1,293 @@
+import {
+  For,
+  Show,
+  createSignal,
+  createEffect,
+  onCleanup,
+  createUniqueId,
+  type Accessor,
+} from "solid-js";
+import { Portal } from "solid-js/web";
+
+export interface AppSelectOption {
+  value: string;
+  label: string;
+  disabled?: boolean;
+}
+
+export interface AppSelectProps {
+  options: AppSelectOption[];
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+  placeholder?: string;
+  id?: string;
+  class?: string;
+}
+
+interface DropdownPos {
+  top: number;
+  left: number;
+  width: number;
+  openUpward: boolean;
+}
+
+export default function AppSelect(props: AppSelectProps) {
+  const triggerId = createUniqueId();
+  const listboxId = createUniqueId();
+
+  // Callback refs so static analysis can see the assignment
+  let triggerRef: HTMLButtonElement | undefined = undefined;
+  let listboxRef: HTMLUListElement | undefined = undefined;
+
+  const [open, setOpen] = createSignal(false);
+  const [focusedIndex, setFocusedIndex] = createSignal(-1);
+  const [pos, setPos] = createSignal<DropdownPos>({
+    top: 0,
+    left: 0,
+    width: 0,
+    openUpward: false,
+  });
+
+  // Derive enabled-option indices for keyboard nav
+  const enabledIndices: Accessor<number[]> = () =>
+    props.options.map((o, i) => (o.disabled ? -1 : i)).filter((i) => i !== -1);
+
+  const selectedLabel = () =>
+    props.options.find((o) => o.value === props.value)?.label ?? props.placeholder ?? "";
+
+  // ── Position calculation ────────────────────────────────────────────────
+  function calcPos(): DropdownPos {
+    if (!triggerRef) return { top: 0, left: 0, width: 0, openUpward: false };
+    const r = triggerRef.getBoundingClientRect();
+    const dropdownMaxH = 240;
+    const spaceBelow = window.innerHeight - r.bottom;
+    const openUpward = spaceBelow < dropdownMaxH && r.top > dropdownMaxH;
+    return {
+      top: openUpward ? r.top + window.scrollY - dropdownMaxH - 4 : r.bottom + window.scrollY + 4,
+      left: r.left + window.scrollX,
+      width: r.width,
+      openUpward,
+    };
+  }
+
+  // ── Open / close ─────────────────────────────────────────────────────────
+  function openDropdown() {
+    if (props.disabled) return;
+    setPos(calcPos());
+    const idx = props.options.findIndex((o) => o.value === props.value);
+    setFocusedIndex(idx >= 0 ? idx : (enabledIndices()[0] ?? -1));
+    setOpen(true);
+  }
+
+  function closeDropdown() {
+    setOpen(false);
+    setFocusedIndex(-1);
+    triggerRef?.focus();
+  }
+
+  function selectOption(value: string) {
+    props.onChange(value);
+    closeDropdown();
+  }
+
+  // ── Scroll focused option into view ──────────────────────────────────────
+  createEffect(() => {
+    const idx = focusedIndex();
+    if (!open() || idx < 0 || !listboxRef) return;
+    const el = listboxRef.children[idx] as HTMLElement | undefined;
+    el?.scrollIntoView({ block: "nearest" });
+  });
+
+  // ── Reposition on scroll / resize while open ─────────────────────────────
+  createEffect(() => {
+    if (!open()) return;
+    const update = () => setPos(calcPos());
+    window.addEventListener("scroll", update, { passive: true, capture: true });
+    window.addEventListener("resize", update, { passive: true });
+    onCleanup(() => {
+      window.removeEventListener("scroll", update, { capture: true });
+      window.removeEventListener("resize", update);
+    });
+  });
+
+  // ── Click outside ────────────────────────────────────────────────────────
+  createEffect(() => {
+    if (!open()) return;
+    function handler(e: MouseEvent) {
+      const t = e.target as Node;
+      if (!triggerRef?.contains(t) && !listboxRef?.contains(t)) {
+        setOpen(false);
+        setFocusedIndex(-1);
+      }
+    }
+    // Small delay so the trigger's own click doesn't immediately re-close
+    const id = setTimeout(() => document.addEventListener("mousedown", handler), 0);
+    onCleanup(() => {
+      clearTimeout(id);
+      document.removeEventListener("mousedown", handler);
+    });
+  });
+
+  // ── Keyboard: trigger ────────────────────────────────────────────────────
+  function handleTriggerKeyDown(e: KeyboardEvent) {
+    if (props.disabled) return;
+    switch (e.key) {
+      case "Enter":
+      case " ":
+      case "ArrowDown":
+      case "ArrowUp":
+        e.preventDefault();
+        openDropdown();
+        break;
+    }
+  }
+
+  // ── Keyboard: listbox ─────────────────────────────────────────────────────
+  function handleListKeyDown(e: KeyboardEvent) {
+    const enabled = enabledIndices();
+    if (enabled.length === 0) return;
+
+    switch (e.key) {
+      case "ArrowDown": {
+        e.preventDefault();
+        const cur = focusedIndex();
+        const next = enabled.find((i) => i > cur) ?? enabled[0]!;
+        setFocusedIndex(next);
+        break;
+      }
+      case "ArrowUp": {
+        e.preventDefault();
+        const cur = focusedIndex();
+        const prev = [...enabled].reverse().find((i) => i < cur) ?? enabled[enabled.length - 1]!;
+        setFocusedIndex(prev);
+        break;
+      }
+      case "Home":
+        e.preventDefault();
+        setFocusedIndex(enabled[0]!);
+        break;
+      case "End":
+        e.preventDefault();
+        setFocusedIndex(enabled[enabled.length - 1]!);
+        break;
+      case "Enter":
+      case " ": {
+        e.preventDefault();
+        const idx = focusedIndex();
+        const opt = props.options[idx];
+        if (opt && !opt.disabled) selectOption(opt.value);
+        break;
+      }
+      case "Escape":
+      case "Tab":
+        closeDropdown();
+        break;
+    }
+  }
+
+  return (
+    <>
+      {/* Trigger */}
+      <button
+        ref={(el) => (triggerRef = el)}
+        type="button"
+        id={props.id ?? triggerId}
+        role="combobox"
+        aria-haspopup="listbox"
+        aria-expanded={open()}
+        aria-controls={open() ? listboxId : undefined}
+        aria-disabled={props.disabled}
+        disabled={props.disabled}
+        class={`sp-select-trigger${props.class ? ` ${props.class}` : ""}`}
+        classList={{ "sp-select-trigger-open": open() }}
+        onClick={() => (open() ? closeDropdown() : openDropdown())}
+        onKeyDown={handleTriggerKeyDown}
+      >
+        <span class="sp-select-value">{selectedLabel()}</span>
+        <svg
+          class="sp-select-chevron"
+          classList={{ "sp-select-chevron-open": open() }}
+          width="12"
+          height="12"
+          viewBox="0 0 12 12"
+          fill="none"
+          stroke="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M3 4.5l3 3 3-3"
+          />
+        </svg>
+      </button>
+
+      {/* Dropdown portal */}
+      <Show when={open()}>
+        <Portal>
+          <ul
+            ref={(el) => (listboxRef = el)}
+            id={listboxId}
+            role="listbox"
+            aria-labelledby={props.id ?? triggerId}
+            tabIndex={-1}
+            class="sp-select-listbox"
+            classList={{ "sp-select-listbox-upward": pos().openUpward }}
+            style={{
+              position: "absolute",
+              top: `${pos().top}px`,
+              left: `${pos().left}px`,
+              width: `${pos().width}px`,
+              "z-index": "9999",
+            }}
+            onKeyDown={handleListKeyDown}
+            onMouseLeave={() => setFocusedIndex(-1)}
+          >
+            <For each={props.options}>
+              {(option, index) => (
+                <li
+                  role="option"
+                  aria-selected={option.value === props.value}
+                  aria-disabled={option.disabled}
+                  class="sp-select-option"
+                  classList={{
+                    "sp-select-option-selected": option.value === props.value,
+                    "sp-select-option-focused": index() === focusedIndex(),
+                    "sp-select-option-disabled": !!option.disabled,
+                  }}
+                  onMouseEnter={() => !option.disabled && setFocusedIndex(index())}
+                  onMouseDown={(e) => {
+                    e.preventDefault(); // keep focus on listbox
+                    if (!option.disabled) selectOption(option.value);
+                  }}
+                >
+                  {option.label}
+                  <Show when={option.value === props.value}>
+                    <svg
+                      class="sp-select-check"
+                      width="12"
+                      height="12"
+                      viewBox="0 0 12 12"
+                      fill="none"
+                      stroke="currentColor"
+                      aria-hidden="true"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2.5"
+                        d="M2 6l3 3 5-5"
+                      />
+                    </svg>
+                  </Show>
+                </li>
+              )}
+            </For>
+          </ul>
+        </Portal>
+      </Show>
+    </>
+  );
+}

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -23,6 +23,10 @@ export const ROUTES = {
   CHANGELOG: "/changelog",
 } as const;
 
+// Resize unit DPI options (used when unit is 'in' or 'cm')
+export const DPI_OPTIONS = [72, 96, 150, 300] as const;
+export const DEFAULT_DPI = 96;
+
 // File size limits (in bytes)
 export const MAX_FILE_SIZE = 50 * 1024 * 1024;
 export const RECOMMENDED_MAX_SIZE = 10 * 1024 * 1024;

--- a/src/config/presets.ts
+++ b/src/config/presets.ts
@@ -1,0 +1,20 @@
+/**
+ * Social media dimension presets for the resize panel.
+ * All dimensions are in pixels.
+ */
+
+export interface SocialMediaPreset {
+  label: string;
+  width: number;
+  height: number;
+}
+
+export const SOCIAL_MEDIA_PRESETS: SocialMediaPreset[] = [
+  { label: "Instagram Post", width: 1080, height: 1080 },
+  { label: "Instagram Story", width: 1080, height: 1920 },
+  { label: "Twitter / X Post", width: 1200, height: 675 },
+  { label: "Facebook Post", width: 1200, height: 630 },
+  { label: "LinkedIn Post", width: 1200, height: 627 },
+  { label: "YouTube Thumbnail", width: 1280, height: 720 },
+  { label: "OG Image", width: 1200, height: 630 },
+];

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -420,6 +420,138 @@ body {
   cursor: not-allowed;
 }
 
+/* ===== AppSelect — custom accessible select ===== */
+.sp-select-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--sp-border);
+  border-radius: var(--sp-radius);
+  font-family: var(--sp-font-body);
+  font-size: 0.85rem;
+  color: var(--sp-text);
+  background: var(--sp-bg);
+  cursor: pointer;
+  text-align: left;
+  transition:
+    border-color 0.2s,
+    box-shadow 0.2s;
+  /* Match the existing input height/style */
+  line-height: 1.4;
+}
+
+.sp-select-trigger:focus-visible {
+  outline: none;
+  border-color: var(--sp-lavender);
+  box-shadow: 0 0 0 3px rgba(167, 139, 250, 0.15);
+}
+
+.sp-select-trigger:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.sp-select-trigger-open {
+  border-color: var(--sp-lavender);
+  box-shadow: 0 0 0 3px rgba(167, 139, 250, 0.15);
+}
+
+.sp-select-value {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--sp-text);
+}
+
+.sp-select-chevron {
+  flex-shrink: 0;
+  color: var(--sp-lavender);
+  transition: transform 0.2s ease;
+}
+
+.sp-select-chevron-open {
+  transform: rotate(180deg);
+}
+
+.sp-select-listbox {
+  list-style: none;
+  margin: 0;
+  padding: 0.25rem;
+  background: var(--sp-bg-card);
+  border: 1px solid var(--sp-border);
+  border-radius: var(--sp-radius);
+  box-shadow: var(--sp-shadow-hover);
+  max-height: 240px;
+  overflow-y: auto;
+  /* Smooth appear */
+  animation: sp-select-in 0.12s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+@keyframes sp-select-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+.sp-select-listbox-upward {
+  animation: sp-select-in-up 0.12s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+@keyframes sp-select-in-up {
+  from {
+    opacity: 0;
+    transform: translateY(4px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+.sp-select-option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.45rem 0.65rem;
+  border-radius: calc(var(--sp-radius) - 4px);
+  font-family: var(--sp-font-body);
+  font-size: 0.85rem;
+  color: var(--sp-text);
+  cursor: pointer;
+  user-select: none;
+  transition: background 0.1s;
+}
+
+.sp-select-option-focused {
+  background: var(--sp-lavender-light);
+  color: var(--sp-lavender-dark);
+}
+
+.sp-select-option-selected {
+  font-weight: 600;
+  color: var(--sp-lavender-dark);
+}
+
+.sp-select-option-disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.sp-select-check {
+  flex-shrink: 0;
+  color: var(--sp-lavender-dark);
+}
+
 .info-icon {
   display: inline-flex;
   align-items: center;

--- a/src/types/processing.ts
+++ b/src/types/processing.ts
@@ -1,6 +1,11 @@
 import type { ImageFormat } from "./image";
 
 /**
+ * Supported resize units
+ */
+export type ResizeUnit = "px" | "%" | "in" | "cm";
+
+/**
  * Options for resizing images
  */
 export interface ResizeOptions {

--- a/src/utils/imageUtils.test.ts
+++ b/src/utils/imageUtils.test.ts
@@ -8,6 +8,8 @@ import {
   calculateWidthFromHeight,
   clamp,
   generateId,
+  convertToPx,
+  convertFromPx,
 } from "./imageUtils";
 import { setupBrowserMocks, restoreMocks } from "../test/mocks";
 
@@ -175,5 +177,76 @@ describe("generateId", () => {
   it("returns unique values across calls", () => {
     const ids = new Set(Array.from({ length: 20 }, () => generateId()));
     expect(ids.size).toBe(20);
+  });
+});
+
+describe("convertToPx", () => {
+  const originalPx = 1920;
+  const dpi = 96;
+
+  it("px: returns the value rounded", () => {
+    expect(convertToPx(1080, "px", originalPx, dpi)).toBe(1080);
+    expect(convertToPx(1080.6, "px", originalPx, dpi)).toBe(1081);
+  });
+
+  it("%: converts percentage of original dimension", () => {
+    expect(convertToPx(50, "%", 1920, dpi)).toBe(960);
+    expect(convertToPx(100, "%", 1920, dpi)).toBe(1920);
+    expect(convertToPx(25, "%", 1000, dpi)).toBe(250);
+  });
+
+  it("%: ignores dpi", () => {
+    expect(convertToPx(50, "%", 1920, 72)).toBe(convertToPx(50, "%", 1920, 300));
+  });
+
+  it("in: converts inches to pixels using dpi", () => {
+    expect(convertToPx(10, "in", originalPx, 96)).toBe(960);
+    expect(convertToPx(1, "in", originalPx, 300)).toBe(300);
+  });
+
+  it("cm: converts centimetres to pixels using dpi", () => {
+    expect(convertToPx(2.54, "cm", originalPx, 96)).toBe(96);
+    expect(convertToPx(25.4, "cm", originalPx, 96)).toBe(960);
+  });
+});
+
+describe("convertFromPx", () => {
+  const originalPx = 1920;
+  const dpi = 96;
+
+  it("px: returns the value unchanged", () => {
+    expect(convertFromPx(1080, "px", originalPx, dpi)).toBe(1080);
+  });
+
+  it("%: converts px back to percentage of original", () => {
+    expect(convertFromPx(960, "%", 1920, dpi)).toBe(50);
+    expect(convertFromPx(1920, "%", 1920, dpi)).toBe(100);
+  });
+
+  it("%: returns 0 when originalPx is 0", () => {
+    expect(convertFromPx(100, "%", 0, dpi)).toBe(0);
+  });
+
+  it("in: converts px back to inches", () => {
+    expect(convertFromPx(960, "in", originalPx, 96)).toBeCloseTo(10);
+    expect(convertFromPx(300, "in", originalPx, 300)).toBeCloseTo(1);
+  });
+
+  it("cm: converts px back to centimetres", () => {
+    expect(convertFromPx(96, "cm", originalPx, 96)).toBeCloseTo(2.54);
+    expect(convertFromPx(960, "cm", originalPx, 96)).toBeCloseTo(25.4);
+  });
+
+  it("in: returns 0 when dpi is 0", () => {
+    expect(convertFromPx(100, "in", originalPx, 0)).toBe(0);
+  });
+
+  it("round-trip px → unit → px stays within 1px", () => {
+    const px = 1280;
+    for (const unit of ["px", "%", "in", "cm"] as const) {
+      const display = convertFromPx(px, unit, originalPx, dpi);
+      const backToPx = convertToPx(display, unit, originalPx, dpi);
+      expect(Math.abs(backToPx - px)).toBeLessThanOrEqual(1);
+    }
   });
 });

--- a/src/utils/imageUtils.ts
+++ b/src/utils/imageUtils.ts
@@ -91,6 +91,54 @@ export function calculateWidthFromHeight(
 }
 
 /**
+ * Convert a value in display units to pixels.
+ * - px: identity
+ * - %: percentage of the original dimension in pixels
+ * - in: inches × DPI
+ * - cm: centimetres × DPI ÷ 2.54
+ */
+export function convertToPx(
+  value: number,
+  unit: import("../types/processing").ResizeUnit,
+  originalPx: number,
+  dpi: number
+): number {
+  switch (unit) {
+    case "px":
+      return Math.round(value);
+    case "%":
+      return Math.round((value / 100) * originalPx);
+    case "in":
+      return Math.round(value * dpi);
+    case "cm":
+      return Math.round((value * dpi) / 2.54);
+  }
+}
+
+/**
+ * Convert pixels back to display units.
+ * The inverse of convertToPx — used when switching units to preserve the
+ * user's entered value.
+ */
+export function convertFromPx(
+  px: number,
+  unit: import("../types/processing").ResizeUnit,
+  originalPx: number,
+  dpi: number
+): number {
+  switch (unit) {
+    case "px":
+      return px;
+    case "%":
+      return originalPx === 0 ? 0 : (px / originalPx) * 100;
+    case "in":
+      return dpi === 0 ? 0 : px / dpi;
+    case "cm":
+      return dpi === 0 ? 0 : (px * 2.54) / dpi;
+  }
+}
+
+/**
  * Clamp a number between min and max values
  */
 export function clamp(value: number, min: number, max: number): number {


### PR DESCRIPTION
## Summary

Implements three related improvements to the resize and format controls.

### Multi-unit resize support
- Added `ResizeUnit` type (`px`, `%`, `in`, `cm`) to `src/types/processing.ts`
- Added `convertToPx` / `convertFromPx` utilities in `src/utils/imageUtils.ts` with full test coverage
- Unit conversion is purely UI-side — the service layer always receives pixels, nothing below `ImageApp` changed
- Switching units auto-converts existing field values so no work is lost
- Width/height placeholders update to show the original image dimensions in the selected unit

### DPI selector for physical units
- A Resolution selector (72 / 96 / 150 / 300 DPI, default 96) appears inline when `in` or `cm` is selected
- Changing DPI also auto-converts existing field values
- An info tooltip explains DPI in plain language: "Use 96 for screen, 300 for print"

### Custom AppSelect component (fixes native-select inconsistency)
- New `src/components/shared/AppSelect.tsx` — lightweight SolidJS component, no new runtime dependencies
- Fully keyboard navigable (arrows, Enter/Space, Escape, Home/End, Tab)
- ARIA-correct: role=combobox, role=listbox, role=option, aria-expanded, aria-selected
- Portal-rendered dropdown so it never clips inside containers
- Chevron animates open/closed; selected item shows a check mark
- Replaces the native `<select>` for Format and all new selectors

### Social media dimension presets (closes #25)
- New `src/config/presets.ts` with 7 platform presets (Instagram, Twitter/X, Facebook, LinkedIn, YouTube, OG Image)
- Selecting a preset sets both W/H atomically, forces unit back to px, and bypasses aspect-ratio lock
- Manually editing W/H after selecting a preset resets the dropdown back to Custom

## Commits
- `feat(resize): add ResizeUnit type, DPI constants, and unit utils`
- `feat(presets): add social media dimension presets config`
- `feat(ui): add AppSelect custom accessible select component`
- `feat(resize): wire unit/DPI/preset controls into app and UI`

## Checklist
- [x] `bun run type-check` passes
- [x] `bun run lint` passes
- [x] `bun run format:check` passes
- [x] `bun run test` passes (103 tests)
- [x] `bun run build` passes
- [x] Closes #25
