### PR TITLE
ci: harden release-please automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version-file: ".bun-version"
-          cache: true
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.prettierignore
+++ b/.prettierignore
@@ -16,3 +16,6 @@ yarn.lock
 
 # Cache
 .cache/
+
+# Release Please output
+CHANGELOG.md

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
+  "include-component-in-tag": false,
+  "bootstrap-sha": "6b3344c8b4488a695eacaaeeac5b3506db6b71df",
   "packages": {
     ".": {}
   },


### PR DESCRIPTION
## Summary
- ignore the Release Please-generated `CHANGELOG.md` in Prettier checks so release PRs stop failing CI
- explicitly pin Release Please to plain `v<version>` tags and bootstrap it from the `v0.6.1` baseline commit
- remove the unsupported `cache: true` input from `oven-sh/setup-bun@v2` to eliminate CI noise

## Why
The current Release Please PR (#56) is failing for two separate reasons:
1. `prettier --check .` is validating the autogenerated `CHANGELOG.md`, which Release Please does not format to this repo's Prettier rules.
2. Release Please was still inferring component-style tag lookup during bootstrap, so it started pulling old history instead of respecting the new `v0.6.1` baseline.

## Validation
- `bun run verify`
- `npx -y release-please release-pr --token "$(gh auth token)" --repo-url abijith-suresh/reshrimp --target-branch fix/release-please-ci-changelog --dry-run --debug` → found `v0.6.1` and would open **0** PRs
