### PR TITLE
ci: add node setup for Astro compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:


### PR DESCRIPTION
## Summary

Add `actions/setup-node@v5` with `node-version: 24` to the CI workflow for Astro/tooling runtime compatibility.

### What changed

- **Only** `.github/workflows/ci.yml` was modified
- Added `actions/setup-node@v5` step with `node-version: 24`, placed **before** Bun setup

### What did NOT change

- Bun remains the **package manager**, **lockfile manager**, and **script runner**
- All existing steps preserved: Bun setup, `bun install --frozen-lockfile`, `bun run verify`, dependency review
- No scripts renamed, no config files altered

### Checklist

- [x] Only CI workflow modified
- [x] Node 24 setup placed before Bun setup
- [x] Bun remains sole package manager and script runner
- [x] Local `bun run verify` passed (type-check, lint, format, test, build)
- [x] No unrelated changes