### PR TITLE
fix: tighten object URL lifecycle

### DIFF
--- a/src/components/app/ImageApp.tsx
+++ b/src/components/app/ImageApp.tsx
@@ -2,9 +2,13 @@ import { createSignal, createMemo, createEffect, onCleanup, type Setter } from "
 import type { ProcessedImage, ValidationResult, ImageFormat } from "@/types/image";
 import type { ProcessResult, ResizeUnit } from "@/types/processing";
 import { processImage, getImageMetadata } from "@/services/imageService";
+import {
+  downloadProcessedBlob,
+  replaceObjectUrl,
+  revokeImageUrls,
+} from "@/services/imageSessionService";
 import { validateImageFile, generateDownloadFilename } from "@/services/validationService";
 import {
-  createDownloadLink,
   formatFileSize,
   generateId,
   calculateHeightFromWidth,
@@ -61,16 +65,8 @@ export default function ImageApp() {
   const [dpiValue, setDpiValue] = createSignal(DEFAULT_DPI);
   const [presetValue, setPresetValue] = createSignal("");
 
-  // ── Object URL tracking for cleanup ──────────────────────────────────────
-  const [objectUrls, setObjectUrls] = createSignal<string[]>([]);
-
-  function trackUrl(url: string): string {
-    setObjectUrls((prev) => [...prev, url]);
-    return url;
-  }
-
   onCleanup(() => {
-    objectUrls().forEach((url) => URL.revokeObjectURL(url));
+    revokeImageUrls(currentImage());
   });
 
   // ── Derived signals ───────────────────────────────────────────────────────
@@ -128,12 +124,12 @@ export default function ImageApp() {
 
     try {
       const metadata = await getImageMetadata(file);
-      const url = trackUrl(URL.createObjectURL(file));
+      const originalUrl = URL.createObjectURL(file);
 
       const processedImage: ProcessedImage = {
         id: generateId(),
         file,
-        originalUrl: url,
+        originalUrl,
         processedUrl: null,
         metadata,
         processing: false,
@@ -141,7 +137,10 @@ export default function ImageApp() {
       };
 
       // Reset stale state when a new file is loaded
-      setCurrentImage(processedImage);
+      setCurrentImage((previousImage) => {
+        revokeImageUrls(previousImage);
+        return processedImage;
+      });
       setProcessResult(null);
       setActiveTab("original");
       setError(null);
@@ -218,7 +217,7 @@ export default function ImageApp() {
           : undefined
       );
 
-      const processedUrl = trackUrl(URL.createObjectURL(result.blob));
+      const processedUrl = replaceObjectUrl(img.processedUrl, result.blob);
 
       setCurrentImage((prev) => (prev ? { ...prev, processedUrl } : null));
       setProcessResult(result);
@@ -233,7 +232,8 @@ export default function ImageApp() {
 
   function handleDownload(): void {
     const img = currentImage();
-    if (!img?.processedUrl) return;
+    const result = processResult();
+    if (!img?.processedUrl || !result) return;
 
     const targetFormat: ImageFormat = removeBackground()
       ? "image/png"
@@ -241,13 +241,12 @@ export default function ImageApp() {
 
     const filename = generateDownloadFilename(img.metadata.fileName, targetFormat);
 
-    fetch(img.processedUrl)
-      .then((r) => r.blob())
-      .then((blob) => createDownloadLink(blob, filename))
-      .catch((err) => {
-        setError("Failed to download image");
-        console.error("Download error:", err);
-      });
+    try {
+      downloadProcessedBlob(result.blob, filename);
+    } catch (err) {
+      setError("Failed to download image");
+      console.error("Download error:", err);
+    }
   }
 
   function handleRemoveBackgroundChange(checked: boolean): void {

--- a/src/services/imageSessionService.test.ts
+++ b/src/services/imageSessionService.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setupBrowserMocks, restoreMocks } from "../test/mocks";
+
+vi.mock("../utils/imageUtils", () => ({
+  createDownloadLink: vi.fn(),
+}));
+
+import { createDownloadLink } from "../utils/imageUtils";
+import { downloadProcessedBlob, replaceObjectUrl, revokeImageUrls } from "./imageSessionService";
+
+const mockCreateDownloadLink = vi.mocked(createDownloadLink);
+
+beforeEach(() => {
+  setupBrowserMocks();
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  restoreMocks();
+});
+
+describe("replaceObjectUrl", () => {
+  it("revokes the previous URL before creating the next one", () => {
+    const blob = new Blob(["processed"], { type: "image/png" });
+
+    const nextUrl = replaceObjectUrl("blob:previous", blob);
+
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:previous");
+    expect(URL.createObjectURL).toHaveBeenCalledWith(blob);
+    expect(nextUrl).toBe("blob:mock-url");
+  });
+});
+
+describe("downloadProcessedBlob", () => {
+  it("downloads directly from the processed blob", () => {
+    const blob = new Blob(["processed"], { type: "image/png" });
+
+    downloadProcessedBlob(blob, "result.png");
+
+    expect(mockCreateDownloadLink).toHaveBeenCalledWith(blob, "result.png");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe("revokeImageUrls", () => {
+  it("revokes both original and processed URLs for the current session", () => {
+    revokeImageUrls({
+      originalUrl: "blob:original",
+      processedUrl: "blob:processed",
+    });
+
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:original");
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:processed");
+  });
+});

--- a/src/services/imageSessionService.ts
+++ b/src/services/imageSessionService.ts
@@ -1,0 +1,30 @@
+import { createDownloadLink } from "../utils/imageUtils";
+
+export function replaceObjectUrl(previousUrl: string | null, blob: Blob): string {
+  if (previousUrl) {
+    URL.revokeObjectURL(previousUrl);
+  }
+
+  return URL.createObjectURL(blob);
+}
+
+export function downloadProcessedBlob(blob: Blob, filename: string): void {
+  createDownloadLink(blob, filename);
+}
+
+export function revokeImageUrls(
+  urls: {
+    originalUrl: string;
+    processedUrl: string | null;
+  } | null
+): void {
+  if (!urls) {
+    return;
+  }
+
+  URL.revokeObjectURL(urls.originalUrl);
+
+  if (urls.processedUrl) {
+    URL.revokeObjectURL(urls.processedUrl);
+  }
+}


### PR DESCRIPTION
## Summary
Tighten object URL cleanup in the app workflow and stop re-fetching processed object URLs before download. This keeps repeated processing sessions from accumulating stale URLs while preserving the existing preview and filename behavior.

## Changes
- revoke superseded original and processed object URLs when a new session or processed result replaces them
- add an image session service that centralizes object URL replacement, cleanup, and direct blob downloads
- cover the URL lifecycle and direct-download path with focused unit tests

## Testing
- [x] bun run verify
- [x] Repeat URL replacement and cleanup behavior through new unit coverage

## References
- Issue: #70
- Fixes #70