### PR TITLE
refactor: extract image workflow orchestration

### DIFF
--- a/src/components/app/ImageApp.tsx
+++ b/src/components/app/ImageApp.tsx
@@ -7,15 +7,16 @@ import {
   replaceObjectUrl,
   revokeImageUrls,
 } from "@/services/imageSessionService";
-import { validateImageFile, generateDownloadFilename } from "@/services/validationService";
 import {
-  formatFileSize,
-  generateId,
-  calculateHeightFromWidth,
-  calculateWidthFromHeight,
-  convertToPx,
-  convertFromPx,
-} from "@/utils/imageUtils";
+  buildProcessOptions,
+  getDimensionValuesForDpiChange,
+  getFormatStateForBackgroundRemoval,
+  getLinkedDimensionValues,
+  getPresetResizeValues,
+  rebaseDimensionValues,
+} from "@/services/imageWorkflowService";
+import { validateImageFile, generateDownloadFilename } from "@/services/validationService";
+import { formatFileSize, generateId, convertFromPx } from "@/utils/imageUtils";
 import { DEFAULT_DPI } from "@/config/constants";
 import { SOCIAL_MEDIA_PRESETS } from "@/config/presets";
 import UploadArea from "./UploadArea";
@@ -174,29 +175,18 @@ export default function ImageApp() {
     const img = currentImage();
     if (!img || isProcessing()) return;
 
-    const unit = resizeUnit();
-    const dpi = dpiValue();
-
-    const wRaw = widthValue() ? parseFloat(widthValue()) : NaN;
-    const hRaw = heightValue() ? parseFloat(heightValue()) : NaN;
-
-    const widthPx = isNaN(wRaw) ? undefined : convertToPx(wRaw, unit, img.metadata.width, dpi);
-    const heightPx = isNaN(hRaw) ? undefined : convertToPx(hRaw, unit, img.metadata.height, dpi);
-
-    const options = {
+    const options = buildProcessOptions({
+      originalWidth: img.metadata.width,
+      originalHeight: img.metadata.height,
+      widthValue: widthValue(),
+      heightValue: heightValue(),
+      maintainAspectRatio: maintainAspectRatio(),
       removeBackground: removeBackground(),
-      ...(widthPx || heightPx
-        ? {
-            resize: {
-              width: widthPx,
-              height: heightPx,
-              maintainAspectRatio: maintainAspectRatio(),
-            },
-          }
-        : {}),
-      ...(formatValue() ? { format: formatValue() as ImageFormat } : {}),
-      quality: qualityValue() / 100,
-    };
+      formatValue: formatValue(),
+      qualityValue: qualityValue(),
+      resizeUnit: resizeUnit(),
+      dpi: dpiValue(),
+    });
 
     setIsProcessing(true);
     setError(null);
@@ -250,42 +240,33 @@ export default function ImageApp() {
   }
 
   function handleRemoveBackgroundChange(checked: boolean): void {
-    if (checked) {
-      setPreviousFormatValue(formatValue());
-      setFormatValue("image/png");
-    } else {
-      setFormatValue(previousFormatValue());
-    }
-    setRemoveBackground(checked);
-  }
+    const nextFormatState = getFormatStateForBackgroundRemoval({
+      checked,
+      formatValue: formatValue(),
+      previousFormatValue: previousFormatValue(),
+    });
 
-  /**
-   * Convert an existing display value between units.
-   * Returns the new display string, or "" if the input is empty/invalid.
-   */
-  function rebaseValue(
-    displayStr: string,
-    oldUnit: ResizeUnit,
-    newUnit: ResizeUnit,
-    originalPx: number,
-    dpi: number
-  ): string {
-    if (!displayStr) return "";
-    const num = parseFloat(displayStr);
-    if (isNaN(num)) return "";
-    const px = convertToPx(num, oldUnit, originalPx, dpi);
-    const newDisplay = convertFromPx(px, newUnit, originalPx, dpi);
-    return formatUnitValue(newDisplay, newUnit);
+    setPreviousFormatValue(nextFormatState.previousFormatValue);
+    setFormatValue(nextFormatState.formatValue);
+    setRemoveBackground(checked);
   }
 
   function handleUnitChange(newUnit: ResizeUnit): void {
     const img = currentImage();
-    const oldUnit = resizeUnit();
-    const dpi = dpiValue();
 
     if (img) {
-      setWidthValue(rebaseValue(widthValue(), oldUnit, newUnit, img.metadata.width, dpi));
-      setHeightValue(rebaseValue(heightValue(), oldUnit, newUnit, img.metadata.height, dpi));
+      const nextDimensions = rebaseDimensionValues({
+        widthValue: widthValue(),
+        heightValue: heightValue(),
+        oldUnit: resizeUnit(),
+        newUnit,
+        originalWidth: img.metadata.width,
+        originalHeight: img.metadata.height,
+        dpi: dpiValue(),
+      });
+
+      setWidthValue(nextDimensions.widthValue);
+      setHeightValue(nextDimensions.heightValue);
     }
 
     setResizeUnit(newUnit);
@@ -293,28 +274,20 @@ export default function ImageApp() {
 
   function handleDpiChange(newDpi: number): void {
     const img = currentImage();
-    const unit = resizeUnit();
-    const oldDpi = dpiValue();
 
-    // Only physical units are affected by DPI changes; % and px are invariant
-    if (img && (unit === "in" || unit === "cm")) {
-      // Convert display → px (old DPI) → display (new DPI)
-      if (widthValue()) {
-        const w = parseFloat(widthValue());
-        if (!isNaN(w)) {
-          const px = convertToPx(w, unit, img.metadata.width, oldDpi);
-          setWidthValue(formatUnitValue(convertFromPx(px, unit, img.metadata.width, newDpi), unit));
-        }
-      }
-      if (heightValue()) {
-        const h = parseFloat(heightValue());
-        if (!isNaN(h)) {
-          const px = convertToPx(h, unit, img.metadata.height, oldDpi);
-          setHeightValue(
-            formatUnitValue(convertFromPx(px, unit, img.metadata.height, newDpi), unit)
-          );
-        }
-      }
+    if (img) {
+      const nextDimensions = getDimensionValuesForDpiChange({
+        widthValue: widthValue(),
+        heightValue: heightValue(),
+        resizeUnit: resizeUnit(),
+        originalWidth: img.metadata.width,
+        originalHeight: img.metadata.height,
+        previousDpi: dpiValue(),
+        nextDpi: newDpi,
+      });
+
+      setWidthValue(nextDimensions.widthValue);
+      setHeightValue(nextDimensions.heightValue);
     }
 
     setDpiValue(newDpi);
@@ -322,66 +295,78 @@ export default function ImageApp() {
 
   function handlePresetChange(label: string): void {
     setPresetValue(label);
-    if (!label) return; // "Custom" — don't touch W/H
+    if (!label) return;
 
-    const preset = SOCIAL_MEDIA_PRESETS.find((p) => p.label === label);
-    if (!preset) return;
+    const presetValues = getPresetResizeValues(label, SOCIAL_MEDIA_PRESETS);
+    if (!presetValues) return;
 
-    // Presets are always in px — switch unit first, then set values atomically
-    // bypassing aspect-ratio linkage by setting both fields directly
-    setResizeUnit("px");
-    setWidthValue(String(preset.width));
-    setHeightValue(String(preset.height));
+    setResizeUnit(presetValues.resizeUnit);
+    setWidthValue(presetValues.widthValue);
+    setHeightValue(presetValues.heightValue);
   }
 
-  /**
-   * Aspect-ratio-aware width handler.
-   * Operates entirely in display units.
-   */
   function handleWidthInput(val: string): void {
-    setWidthValue(val);
-    setPresetValue(""); // user edited manually → reset preset
+    setPresetValue("");
 
-    if (maintainAspectRatio() && val) {
-      const img = currentImage();
-      if (!img) return;
-
-      const num = parseFloat(val);
-      if (isNaN(num)) return;
-
-      const unit = resizeUnit();
-      const dpi = dpiValue();
-
-      // Convert entered width to px, compute linked height in px, convert back
-      const wPx = convertToPx(num, unit, img.metadata.width, dpi);
-      const hPx = calculateHeightFromWidth(img.metadata.width, img.metadata.height, wPx);
-      setHeightValue(formatUnitValue(convertFromPx(hPx, unit, img.metadata.height, dpi), unit));
+    if (!maintainAspectRatio()) {
+      setWidthValue(val);
+      return;
     }
+
+    const img = currentImage();
+    if (!img) {
+      setWidthValue(val);
+      return;
+    }
+
+    const linkedDimensions = getLinkedDimensionValues({
+      changedDimension: "width",
+      value: val,
+      resizeUnit: resizeUnit(),
+      dpi: dpiValue(),
+      originalWidth: img.metadata.width,
+      originalHeight: img.metadata.height,
+    });
+
+    if (!linkedDimensions) {
+      setWidthValue(val);
+      return;
+    }
+
+    setWidthValue(linkedDimensions.widthValue);
+    setHeightValue(linkedDimensions.heightValue);
   }
 
-  /**
-   * Aspect-ratio-aware height handler.
-   * Operates entirely in display units.
-   */
   function handleHeightInput(val: string): void {
-    setHeightValue(val);
-    setPresetValue(""); // user edited manually → reset preset
+    setPresetValue("");
 
-    if (maintainAspectRatio() && val) {
-      const img = currentImage();
-      if (!img) return;
-
-      const num = parseFloat(val);
-      if (isNaN(num)) return;
-
-      const unit = resizeUnit();
-      const dpi = dpiValue();
-
-      // Convert entered height to px, compute linked width in px, convert back
-      const hPx = convertToPx(num, unit, img.metadata.height, dpi);
-      const wPx = calculateWidthFromHeight(img.metadata.width, img.metadata.height, hPx);
-      setWidthValue(formatUnitValue(convertFromPx(wPx, unit, img.metadata.width, dpi), unit));
+    if (!maintainAspectRatio()) {
+      setHeightValue(val);
+      return;
     }
+
+    const img = currentImage();
+    if (!img) {
+      setHeightValue(val);
+      return;
+    }
+
+    const linkedDimensions = getLinkedDimensionValues({
+      changedDimension: "height",
+      value: val,
+      resizeUnit: resizeUnit(),
+      dpi: dpiValue(),
+      originalWidth: img.metadata.width,
+      originalHeight: img.metadata.height,
+    });
+
+    if (!linkedDimensions) {
+      setHeightValue(val);
+      return;
+    }
+
+    setWidthValue(linkedDimensions.widthValue);
+    setHeightValue(linkedDimensions.heightValue);
   }
 
   function handleAspectRatioChange(checked: boolean): void {

--- a/src/services/imageWorkflowService.test.ts
+++ b/src/services/imageWorkflowService.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import { SOCIAL_MEDIA_PRESETS } from "../config/presets";
+import {
+  buildProcessOptions,
+  getDimensionValuesForDpiChange,
+  getFormatStateForBackgroundRemoval,
+  getLinkedDimensionValues,
+  getPresetResizeValues,
+  rebaseDimensionValues,
+} from "./imageWorkflowService";
+
+describe("buildProcessOptions", () => {
+  it("converts display values into processing options", () => {
+    const options = buildProcessOptions({
+      originalWidth: 1200,
+      originalHeight: 800,
+      widthValue: "50",
+      heightValue: "",
+      maintainAspectRatio: true,
+      removeBackground: false,
+      formatValue: "image/webp",
+      qualityValue: 75,
+      resizeUnit: "%",
+      dpi: 96,
+    });
+
+    expect(options).toEqual({
+      resize: {
+        width: 600,
+        maintainAspectRatio: true,
+      },
+      format: "image/webp",
+      quality: 0.75,
+      removeBackground: false,
+    });
+  });
+});
+
+describe("getPresetResizeValues", () => {
+  it("returns px-based resize values for a named preset", () => {
+    expect(getPresetResizeValues("Instagram Story", SOCIAL_MEDIA_PRESETS)).toEqual({
+      resizeUnit: "px",
+      widthValue: "1080",
+      heightValue: "1920",
+    });
+  });
+});
+
+describe("getFormatStateForBackgroundRemoval", () => {
+  it("locks to PNG and restores the previous format selection", () => {
+    const enabled = getFormatStateForBackgroundRemoval({
+      checked: true,
+      formatValue: "image/webp",
+      previousFormatValue: "",
+    });
+    const disabled = getFormatStateForBackgroundRemoval({
+      checked: false,
+      formatValue: enabled.formatValue,
+      previousFormatValue: enabled.previousFormatValue,
+    });
+
+    expect(enabled).toEqual({
+      formatValue: "image/png",
+      previousFormatValue: "image/webp",
+    });
+    expect(disabled).toEqual({
+      formatValue: "image/webp",
+      previousFormatValue: "image/webp",
+    });
+  });
+});
+
+describe("rebaseDimensionValues", () => {
+  it("converts populated width and height values between display units", () => {
+    expect(
+      rebaseDimensionValues({
+        widthValue: "960",
+        heightValue: "540",
+        oldUnit: "px",
+        newUnit: "%",
+        originalWidth: 1920,
+        originalHeight: 1080,
+        dpi: 96,
+      })
+    ).toEqual({
+      widthValue: "50",
+      heightValue: "50",
+    });
+  });
+});
+
+describe("getLinkedDimensionValues", () => {
+  it("derives the paired dimension while preserving the aspect ratio", () => {
+    expect(
+      getLinkedDimensionValues({
+        changedDimension: "width",
+        value: "400",
+        resizeUnit: "px",
+        dpi: 96,
+        originalWidth: 800,
+        originalHeight: 600,
+      })
+    ).toEqual({
+      widthValue: "400",
+      heightValue: "300",
+    });
+  });
+});
+
+describe("getDimensionValuesForDpiChange", () => {
+  it("recalculates physical-unit values against the new DPI", () => {
+    expect(
+      getDimensionValuesForDpiChange({
+        widthValue: "10",
+        heightValue: "5",
+        resizeUnit: "in",
+        originalWidth: 1200,
+        originalHeight: 600,
+        previousDpi: 96,
+        nextDpi: 300,
+      })
+    ).toEqual({
+      widthValue: "3.2",
+      heightValue: "1.6",
+    });
+  });
+});

--- a/src/services/imageWorkflowService.ts
+++ b/src/services/imageWorkflowService.ts
@@ -1,0 +1,250 @@
+import type { ImageFormat } from "../types/image";
+import type { SocialMediaPreset } from "../config/presets";
+import type { ProcessOptions, ResizeUnit } from "../types/processing";
+import {
+  calculateHeightFromWidth,
+  calculateWidthFromHeight,
+  convertFromPx,
+  convertToPx,
+} from "../utils/imageUtils";
+
+interface BuildProcessOptionsInput {
+  originalWidth: number;
+  originalHeight: number;
+  widthValue: string;
+  heightValue: string;
+  maintainAspectRatio: boolean;
+  removeBackground: boolean;
+  formatValue: string;
+  qualityValue: number;
+  resizeUnit: ResizeUnit;
+  dpi: number;
+}
+
+function formatUnitValue(value: number, unit: ResizeUnit): string {
+  if (unit === "px") {
+    return String(Math.round(value));
+  }
+
+  return parseFloat(value.toFixed(2)).toString();
+}
+
+function rebaseDimensionValue(input: {
+  value: string;
+  oldUnit: ResizeUnit;
+  newUnit: ResizeUnit;
+  originalPx: number;
+  dpi: number;
+}): string {
+  if (!input.value) {
+    return "";
+  }
+
+  const numericValue = parseFloat(input.value);
+  if (Number.isNaN(numericValue)) {
+    return "";
+  }
+
+  const px = convertToPx(numericValue, input.oldUnit, input.originalPx, input.dpi);
+  const rebasedValue = convertFromPx(px, input.newUnit, input.originalPx, input.dpi);
+  return formatUnitValue(rebasedValue, input.newUnit);
+}
+
+export function buildProcessOptions(input: BuildProcessOptionsInput): ProcessOptions {
+  const widthNumber = input.widthValue ? parseFloat(input.widthValue) : NaN;
+  const heightNumber = input.heightValue ? parseFloat(input.heightValue) : NaN;
+  const width = Number.isNaN(widthNumber)
+    ? undefined
+    : convertToPx(widthNumber, input.resizeUnit, input.originalWidth, input.dpi);
+  const height = Number.isNaN(heightNumber)
+    ? undefined
+    : convertToPx(heightNumber, input.resizeUnit, input.originalHeight, input.dpi);
+
+  return {
+    ...(width || height
+      ? {
+          resize: {
+            width,
+            height,
+            maintainAspectRatio: input.maintainAspectRatio,
+          },
+        }
+      : {}),
+    ...(input.formatValue ? { format: input.formatValue as ImageFormat } : {}),
+    quality: input.qualityValue / 100,
+    removeBackground: input.removeBackground,
+  };
+}
+
+export function getPresetResizeValues(
+  label: string,
+  presets: ReadonlyArray<SocialMediaPreset>
+): {
+  resizeUnit: "px";
+  widthValue: string;
+  heightValue: string;
+} | null {
+  const preset = presets.find((candidate) => candidate.label === label);
+  if (!preset) {
+    return null;
+  }
+
+  return {
+    resizeUnit: "px",
+    widthValue: String(preset.width),
+    heightValue: String(preset.height),
+  };
+}
+
+function updateDimensionForDpi(
+  value: string,
+  unit: ResizeUnit,
+  originalPx: number,
+  previousDpi: number,
+  nextDpi: number
+): string {
+  if (!value) {
+    return "";
+  }
+
+  const numericValue = parseFloat(value);
+  if (Number.isNaN(numericValue)) {
+    return "";
+  }
+
+  const px = convertToPx(numericValue, unit, originalPx, previousDpi);
+  return formatUnitValue(convertFromPx(px, unit, originalPx, nextDpi), unit);
+}
+
+export function getLinkedDimensionValues(input: {
+  changedDimension: "width" | "height";
+  value: string;
+  resizeUnit: ResizeUnit;
+  dpi: number;
+  originalWidth: number;
+  originalHeight: number;
+}): {
+  widthValue: string;
+  heightValue: string;
+} | null {
+  if (!input.value) {
+    return null;
+  }
+
+  const numericValue = parseFloat(input.value);
+  if (Number.isNaN(numericValue)) {
+    return null;
+  }
+
+  if (input.changedDimension === "width") {
+    const widthPx = convertToPx(numericValue, input.resizeUnit, input.originalWidth, input.dpi);
+    const heightPx = calculateHeightFromWidth(input.originalWidth, input.originalHeight, widthPx);
+
+    return {
+      widthValue: input.value,
+      heightValue: formatUnitValue(
+        convertFromPx(heightPx, input.resizeUnit, input.originalHeight, input.dpi),
+        input.resizeUnit
+      ),
+    };
+  }
+
+  const heightPx = convertToPx(numericValue, input.resizeUnit, input.originalHeight, input.dpi);
+  const widthPx = calculateWidthFromHeight(input.originalWidth, input.originalHeight, heightPx);
+
+  return {
+    widthValue: formatUnitValue(
+      convertFromPx(widthPx, input.resizeUnit, input.originalWidth, input.dpi),
+      input.resizeUnit
+    ),
+    heightValue: input.value,
+  };
+}
+
+export function getDimensionValuesForDpiChange(input: {
+  widthValue: string;
+  heightValue: string;
+  resizeUnit: ResizeUnit;
+  originalWidth: number;
+  originalHeight: number;
+  previousDpi: number;
+  nextDpi: number;
+}): {
+  widthValue: string;
+  heightValue: string;
+} {
+  if (input.resizeUnit === "px" || input.resizeUnit === "%") {
+    return {
+      widthValue: input.widthValue,
+      heightValue: input.heightValue,
+    };
+  }
+
+  return {
+    widthValue: updateDimensionForDpi(
+      input.widthValue,
+      input.resizeUnit,
+      input.originalWidth,
+      input.previousDpi,
+      input.nextDpi
+    ),
+    heightValue: updateDimensionForDpi(
+      input.heightValue,
+      input.resizeUnit,
+      input.originalHeight,
+      input.previousDpi,
+      input.nextDpi
+    ),
+  };
+}
+
+export function rebaseDimensionValues(input: {
+  widthValue: string;
+  heightValue: string;
+  oldUnit: ResizeUnit;
+  newUnit: ResizeUnit;
+  originalWidth: number;
+  originalHeight: number;
+  dpi: number;
+}): {
+  widthValue: string;
+  heightValue: string;
+} {
+  return {
+    widthValue: rebaseDimensionValue({
+      value: input.widthValue,
+      oldUnit: input.oldUnit,
+      newUnit: input.newUnit,
+      originalPx: input.originalWidth,
+      dpi: input.dpi,
+    }),
+    heightValue: rebaseDimensionValue({
+      value: input.heightValue,
+      oldUnit: input.oldUnit,
+      newUnit: input.newUnit,
+      originalPx: input.originalHeight,
+      dpi: input.dpi,
+    }),
+  };
+}
+
+export function getFormatStateForBackgroundRemoval(input: {
+  checked: boolean;
+  formatValue: string;
+  previousFormatValue: string;
+}): {
+  formatValue: string;
+  previousFormatValue: string;
+} {
+  if (input.checked) {
+    return {
+      formatValue: "image/png",
+      previousFormatValue: input.formatValue,
+    };
+  }
+
+  return {
+    formatValue: input.previousFormatValue,
+    previousFormatValue: input.previousFormatValue,
+  };
+}


### PR DESCRIPTION
## Summary
Extract the image workflow rules out of `ImageApp.tsx` into a dedicated service so the top-level component mostly wires UI state and handlers together. The refactor keeps behavior unchanged while making resize conversion, preset synchronization, and process option assembly independently testable.

## Changes
- move process option assembly, background-removal format syncing, unit rebasing, DPI recalculation, preset mapping, and aspect-ratio linking into `src/services/imageWorkflowService.ts`
- update `ImageApp.tsx` to delegate workflow decisions to the extracted helpers instead of embedding the conversion logic inline
- add focused unit coverage for the new workflow service helpers

## Testing
- [x] bun run verify
- [x] Validate extracted workflow helper behavior with new unit tests

## References
- Issue: #68
- Fixes #68