### PR TITLE
feat: self-host background-removal runtime assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Build output
 dist/
 .output/
+public/background-removal/
 
 # Astro
 .astro/

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Visit: https://reshrimp.vercel.app
 - **Image resizing** - Adjust dimensions with various options
 - **Format conversion** - Convert between JPEG, PNG, WebP, and more
 - **Compression** - Optimize file sizes while maintaining quality
-- **Background removal** - Runs locally and works offline after its model assets download once
+- **Background removal** - Runs locally and works offline after its mirrored model assets download once
 - **Single-image processing** - Process one image at a time with resize, format, and quality controls
 - **Privacy first** - No server uploads, everything happens locally
 
@@ -51,19 +51,28 @@ Visit: https://reshrimp.vercel.app
 
 All commands are run from the root of the project:
 
-| Command                | Action                               |
-| :--------------------- | :----------------------------------- |
-| `bun install`          | Install dependencies                 |
-| `bun dev`              | Start dev server at `localhost:4321` |
-| `bun run build`        | Build for production                 |
-| `bun preview`          | Preview production build locally     |
-| `bun run lint`         | Run ESLint                           |
-| `bun run lint:fix`     | Fix ESLint issues                    |
-| `bun run format`       | Format code with Prettier            |
-| `bun run format:check` | Check code formatting                |
-| `bun run test`         | Run tests once                       |
-| `bun run test:watch`   | Run tests in watch mode              |
-| `bun run analyze`      | Analyze bundle size                  |
+| Command                             | Action                                                |
+| :---------------------------------- | :---------------------------------------------------- |
+| `bun install`                       | Install dependencies                                  |
+| `bun run assets:background-removal` | Mirror the required background-removal assets locally |
+| `bun dev`                           | Start dev server at `localhost:4321`                  |
+| `bun run build`                     | Build for production                                  |
+| `bun preview`                       | Preview production build locally                      |
+| `bun run lint`                      | Run ESLint                                            |
+| `bun run lint:fix`                  | Fix ESLint issues                                     |
+| `bun run format`                    | Format code with Prettier                             |
+| `bun run format:check`              | Check code formatting                                 |
+| `bun run test`                      | Run tests once                                        |
+| `bun run test:watch`                | Run tests in watch mode                               |
+| `bun run analyze`                   | Analyze bundle size                                   |
+
+## Background-removal asset delivery
+
+Reshrimp mirrors the minimum background-removal asset set into `public/background-removal/<version>/dist/` before `dev` and `build`.
+
+- runtime requests stay on the app origin instead of depending on a third-party CDN
+- only the CPU ONNX runtime plus the `isnet_fp16` model are mirrored, which keeps the asset footprint around 96 MB instead of shipping the full upstream package
+- the mirror step still needs network access when assets are missing locally, but the deployed app serves and caches those assets itself once built
 
 ## 🤝 Contributing
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "packageManager": "bun@1.3.5",
   "version": "0.6.1",
   "scripts": {
+    "assets:background-removal": "node scripts/sync-background-removal-assets.mjs",
+    "predev": "bun run assets:background-removal",
     "dev": "astro dev",
+    "prebuild": "bun run assets:background-removal",
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",

--- a/scripts/sync-background-removal-assets.mjs
+++ b/scripts/sync-background-removal-assets.mjs
@@ -1,0 +1,120 @@
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const BACKGROUND_REMOVAL_DATA_VERSION = "1.7.0";
+const BACKGROUND_REMOVAL_MODEL = "isnet_fp16";
+const BACKGROUND_REMOVAL_CDN_ORIGIN = "https://staticimgly.com";
+const BACKGROUND_REMOVAL_CDN_PATH_PREFIX = `/@imgly/background-removal-data/${BACKGROUND_REMOVAL_DATA_VERSION}/dist/`;
+const BACKGROUND_REMOVAL_ASSET_KEYS = [
+  "/onnxruntime-web/ort-wasm-simd-threaded.wasm",
+  "/onnxruntime-web/ort-wasm-simd-threaded.mjs",
+  `/models/${BACKGROUND_REMOVAL_MODEL}`,
+];
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(scriptDir, "..");
+const targetDir = path.join(
+  projectRoot,
+  "public",
+  "background-removal",
+  BACKGROUND_REMOVAL_DATA_VERSION,
+  "dist"
+);
+const resourceMapPath = path.join(targetDir, "resources.json");
+const sourceBaseUrl = new URL(BACKGROUND_REMOVAL_CDN_PATH_PREFIX, BACKGROUND_REMOVAL_CDN_ORIGIN);
+
+function getChunkSize(chunk) {
+  return chunk.offsets[1] - chunk.offsets[0];
+}
+
+function hasRequiredAssetMetadata(resourceMap) {
+  return BACKGROUND_REMOVAL_ASSET_KEYS.every((assetKey) => resourceMap?.[assetKey]);
+}
+
+async function fetchJson(url) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+async function readLocalJson(filePath) {
+  try {
+    return JSON.parse(await readFile(filePath, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+async function getResourceMap() {
+  const localResourceMap = await readLocalJson(resourceMapPath);
+  if (hasRequiredAssetMetadata(localResourceMap)) {
+    return localResourceMap;
+  }
+
+  return fetchJson(new URL("resources.json", sourceBaseUrl));
+}
+
+async function hasExpectedSize(filePath, expectedSize) {
+  try {
+    const fileStat = await stat(filePath);
+    return fileStat.size === expectedSize;
+  } catch {
+    return false;
+  }
+}
+
+async function downloadFile(url, destinationPath) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to download ${url}: ${response.status} ${response.statusText}`);
+  }
+
+  const buffer = Buffer.from(await response.arrayBuffer());
+  await writeFile(destinationPath, buffer);
+}
+
+async function main() {
+  await mkdir(targetDir, { recursive: true });
+
+  const resourceMap = await getResourceMap();
+  const filteredResourceMap = {};
+  const chunks = [];
+
+  for (const assetKey of BACKGROUND_REMOVAL_ASSET_KEYS) {
+    const entry = resourceMap[assetKey];
+    if (!entry) {
+      throw new Error(`Missing background-removal asset metadata for ${assetKey}`);
+    }
+
+    filteredResourceMap[assetKey] = entry;
+    chunks.push(...entry.chunks);
+  }
+
+  let downloadedCount = 0;
+
+  for (const chunk of chunks) {
+    const destinationPath = path.join(targetDir, chunk.name);
+    const expectedSize = getChunkSize(chunk);
+
+    if (await hasExpectedSize(destinationPath, expectedSize)) {
+      continue;
+    }
+
+    await downloadFile(new URL(chunk.name, sourceBaseUrl), destinationPath);
+    downloadedCount += 1;
+  }
+
+  await writeFile(resourceMapPath, `${JSON.stringify(filteredResourceMap, null, 2)}\n`);
+
+  console.log(
+    downloadedCount === 0
+      ? "background-removal assets already up to date"
+      : `downloaded ${downloadedCount} background-removal asset chunk(s)`
+  );
+}
+
+await main();

--- a/src/config/backgroundRemoval.ts
+++ b/src/config/backgroundRemoval.ts
@@ -1,8 +1,28 @@
-export const BACKGROUND_REMOVAL_CDN_ORIGIN = "https://staticimgly.com";
 export const BACKGROUND_REMOVAL_DATA_VERSION = "1.7.0";
-export const BACKGROUND_REMOVAL_CDN_PATH_PREFIX = `/@imgly/background-removal-data/${BACKGROUND_REMOVAL_DATA_VERSION}/dist/`;
-export const BACKGROUND_REMOVAL_PUBLIC_PATH = `${BACKGROUND_REMOVAL_CDN_ORIGIN}${BACKGROUND_REMOVAL_CDN_PATH_PREFIX}`;
 export const BACKGROUND_REMOVAL_MODEL = "isnet_fp16" as const;
-export const BACKGROUND_REMOVAL_CDN_CACHE_NAME = "imgly-background-removal-cdn";
+
+/**
+ * Runtime assets are served from the app origin after a build-time mirror step.
+ * This keeps background removal under repository control without shipping the
+ * full upstream asset package.
+ */
+export const BACKGROUND_REMOVAL_ASSET_PATH_PREFIX = `/background-removal/${BACKGROUND_REMOVAL_DATA_VERSION}/dist/`;
+
+/**
+ * The mirror step pulls only the current CPU runtime and fp16 model from the
+ * upstream CDN. Alternate models and GPU/runtime variants stay excluded to keep
+ * deployment size manageable.
+ */
+export const BACKGROUND_REMOVAL_ASSET_KEYS = [
+  "/onnxruntime-web/ort-wasm-simd-threaded.wasm",
+  "/onnxruntime-web/ort-wasm-simd-threaded.mjs",
+  `/models/${BACKGROUND_REMOVAL_MODEL}`,
+] as const;
+
+export const BACKGROUND_REMOVAL_SELF_HOSTED_CACHE_NAME = "imgly-background-removal-self-hosted";
 export const BACKGROUND_REMOVAL_RUNTIME_CACHE_NAME = "imgly-background-removal-runtime";
 export const BACKGROUND_REMOVAL_RUNTIME_ASSET_PATTERN = /\/ort(?:[.-]|$)/;
+
+export function getBackgroundRemovalPublicPath(origin: string): string {
+  return new URL(BACKGROUND_REMOVAL_ASSET_PATH_PREFIX, origin).toString();
+}

--- a/src/services/backgroundRemovalService.test.ts
+++ b/src/services/backgroundRemovalService.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  BACKGROUND_REMOVAL_ASSET_PATH_PREFIX,
   BACKGROUND_REMOVAL_MODEL,
-  BACKGROUND_REMOVAL_PUBLIC_PATH,
+  getBackgroundRemovalPublicPath,
 } from "../config/backgroundRemoval";
 
 vi.mock("@imgly/background-removal", () => ({
@@ -18,6 +19,12 @@ describe("removeBackground", () => {
     vi.clearAllMocks();
   });
 
+  it("builds a same-origin public path for mirrored model assets", () => {
+    expect(getBackgroundRemovalPublicPath("https://reshrimp.test")).toBe(
+      `https://reshrimp.test${BACKGROUND_REMOVAL_ASSET_PATH_PREFIX}`
+    );
+  });
+
   it("forwards the shared model and public path configuration", async () => {
     const file = new File([], "photo.jpg", { type: "image/jpeg" });
 
@@ -27,7 +34,7 @@ describe("removeBackground", () => {
       file,
       expect.objectContaining({
         model: BACKGROUND_REMOVAL_MODEL,
-        publicPath: BACKGROUND_REMOVAL_PUBLIC_PATH,
+        publicPath: getBackgroundRemovalPublicPath(window.location.origin),
       })
     );
   });

--- a/src/services/backgroundRemovalService.ts
+++ b/src/services/backgroundRemovalService.ts
@@ -1,7 +1,7 @@
 import { removeBackground as imglyRemoveBackground } from "@imgly/background-removal";
 import {
   BACKGROUND_REMOVAL_MODEL,
-  BACKGROUND_REMOVAL_PUBLIC_PATH,
+  getBackgroundRemovalPublicPath,
 } from "../config/backgroundRemoval";
 import type { BackgroundRemovalProgressCallback } from "../types/processing";
 
@@ -32,7 +32,7 @@ export async function removeBackground(
   }
 
   config.model = BACKGROUND_REMOVAL_MODEL;
-  config.publicPath = BACKGROUND_REMOVAL_PUBLIC_PATH;
+  config.publicPath = getBackgroundRemovalPublicPath(window.location.origin);
 
   const blob = await imglyRemoveBackground(imageFile, config);
 

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -1,11 +1,10 @@
 /// <reference lib="webworker" />
 
 import {
-  BACKGROUND_REMOVAL_CDN_CACHE_NAME,
-  BACKGROUND_REMOVAL_CDN_ORIGIN,
-  BACKGROUND_REMOVAL_CDN_PATH_PREFIX,
+  BACKGROUND_REMOVAL_ASSET_PATH_PREFIX,
   BACKGROUND_REMOVAL_RUNTIME_ASSET_PATTERN,
   BACKGROUND_REMOVAL_RUNTIME_CACHE_NAME,
+  BACKGROUND_REMOVAL_SELF_HOSTED_CACHE_NAME,
 } from "./config/backgroundRemoval";
 import { clientsClaim, setCacheNameDetails } from "workbox-core";
 import { precacheAndRoute, cleanupOutdatedCaches } from "workbox-precaching";
@@ -36,10 +35,10 @@ self.addEventListener("message", (event) => {
 registerRoute(
   ({ request, url }) =>
     request.method === "GET" &&
-    url.origin === BACKGROUND_REMOVAL_CDN_ORIGIN &&
-    url.pathname.startsWith(BACKGROUND_REMOVAL_CDN_PATH_PREFIX),
+    url.origin === self.location.origin &&
+    url.pathname.startsWith(BACKGROUND_REMOVAL_ASSET_PATH_PREFIX),
   new CacheFirst({
-    cacheName: BACKGROUND_REMOVAL_CDN_CACHE_NAME,
+    cacheName: BACKGROUND_REMOVAL_SELF_HOSTED_CACHE_NAME,
     plugins: [new CacheableResponsePlugin({ statuses: [0, 200] })],
   })
 );


### PR DESCRIPTION
## Summary
Mirror the background-removal runtime assets into the app so production no longer depends on IMG.LY's CDN at request time. The implementation keeps deployment size under control by downloading only the CPU runtime files and the fp16 model before dev/build.

## Changes
- add a build-time asset sync script that mirrors the required background-removal chunks into `public/background-removal/<version>/dist/`
- switch runtime asset loading and service-worker caching to the app origin instead of the third-party CDN
- document the chosen delivery strategy and trade-offs, including the reduced runtime dependency and the mirrored subset size

## Testing
- [x] bun run verify
- [x] Run the asset sync step and confirm builds succeed against the mirrored files

## Notes
This mirrors about 96 MB of runtime assets instead of the full upstream package, which keeps deploy size manageable while preserving same-origin delivery and offline caching.

## References
- Issue: #79
- Fixes #79