### PR TITLE
feat: add batch queue state model

### DIFF
--- a/src/services/batchQueueService.test.ts
+++ b/src/services/batchQueueService.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import type { ProcessedImage } from "../types/image";
+import type { ProcessResult } from "../types/processing";
+import {
+  appendBatchQueueItems,
+  clearBatchQueueState,
+  createBatchQueueItem,
+  createBatchQueueState,
+  getSelectedBatchQueueItem,
+  markBatchQueueItemFailed,
+  markBatchQueueItemProcessing,
+  markBatchQueueItemSucceeded,
+  removeBatchQueueItem,
+} from "./batchQueueService";
+
+function makeProcessedImage(id: string): ProcessedImage {
+  return {
+    id,
+    file: new File([id], `${id}.png`, { type: "image/png" }),
+    originalUrl: `blob:${id}:original`,
+    processedUrl: null,
+    metadata: {
+      width: 1200,
+      height: 800,
+      format: "image/png",
+      fileSize: 1234,
+      fileName: `${id}.png`,
+    },
+    processing: false,
+    error: null,
+  };
+}
+
+function makeProcessResult(): ProcessResult {
+  return {
+    blob: new Blob(["processed"], { type: "image/png" }),
+    metadata: {
+      width: 600,
+      height: 400,
+      format: "image/png",
+      fileSize: 456,
+    },
+  };
+}
+
+describe("batchQueueService", () => {
+  it("treats a single queued image as a selected-item subset of the batch model", () => {
+    const state = createBatchQueueState([createBatchQueueItem(makeProcessedImage("one"))]);
+
+    expect(state.selectedItemId).toBe("one");
+    expect(getSelectedBatchQueueItem(state)?.id).toBe("one");
+  });
+
+  it("appends new items in stable order without disturbing the current selection", () => {
+    const first = createBatchQueueItem(makeProcessedImage("one"));
+    const second = createBatchQueueItem(makeProcessedImage("two"));
+    const state = appendBatchQueueItems(createBatchQueueState([first]), [second]);
+
+    expect(state.items.map((item) => item.id)).toEqual(["one", "two"]);
+    expect(state.selectedItemId).toBe("one");
+  });
+
+  it("marks processing and success while returning superseded processed URLs for cleanup", () => {
+    const item = createBatchQueueItem({
+      ...makeProcessedImage("one"),
+      processedUrl: "blob:one:previous",
+    });
+    const processingState = markBatchQueueItemProcessing(createBatchQueueState([item]), "one");
+    const result = markBatchQueueItemSucceeded(
+      processingState,
+      "one",
+      "blob:one:next",
+      makeProcessResult()
+    );
+
+    expect(getSelectedBatchQueueItem(processingState)?.status).toBe("processing");
+    expect(result.cleanupUrls).toEqual(["blob:one:previous"]);
+    expect(getSelectedBatchQueueItem(result.state)).toMatchObject({
+      status: "succeeded",
+      processedUrl: "blob:one:next",
+      processing: false,
+      error: null,
+    });
+  });
+
+  it("records explicit failed state without dropping queue selection", () => {
+    const state = markBatchQueueItemFailed(
+      createBatchQueueState([createBatchQueueItem(makeProcessedImage("one"))]),
+      "one",
+      "Processing failed"
+    );
+
+    expect(getSelectedBatchQueueItem(state)).toMatchObject({
+      status: "failed",
+      error: "Processing failed",
+      processing: false,
+    });
+    expect(state.selectedItemId).toBe("one");
+  });
+
+  it("removes a queue item, revokes its URLs, and selects a sensible neighbor", () => {
+    const state = createBatchQueueState([
+      createBatchQueueItem(makeProcessedImage("one")),
+      createBatchQueueItem({
+        ...makeProcessedImage("two"),
+        processedUrl: "blob:two:processed",
+      }),
+      createBatchQueueItem(makeProcessedImage("three")),
+    ]);
+    const result = removeBatchQueueItem({ ...state, selectedItemId: "two" }, "two");
+
+    expect(result.cleanupUrls).toEqual(["blob:two:original", "blob:two:processed"]);
+    expect(result.state.items.map((item) => item.id)).toEqual(["one", "three"]);
+    expect(result.state.selectedItemId).toBe("three");
+  });
+
+  it("clears the queue and returns every object URL for cleanup", () => {
+    const state = createBatchQueueState([
+      createBatchQueueItem(makeProcessedImage("one")),
+      createBatchQueueItem({
+        ...makeProcessedImage("two"),
+        processedUrl: "blob:two:processed",
+      }),
+    ]);
+    const result = clearBatchQueueState(state);
+
+    expect(result.state).toEqual({ items: [], selectedItemId: null });
+    expect(result.cleanupUrls).toEqual([
+      "blob:one:original",
+      "blob:two:original",
+      "blob:two:processed",
+    ]);
+  });
+});

--- a/src/services/batchQueueService.ts
+++ b/src/services/batchQueueService.ts
@@ -1,0 +1,142 @@
+import type { ProcessedImage } from "../types/image";
+import type { ProcessResult } from "../types/processing";
+import type { BatchQueueItem, BatchQueueState, BatchQueueTransitionResult } from "../types/batch";
+
+function updateBatchQueueItem(
+  state: BatchQueueState,
+  itemId: string,
+  updater: (item: BatchQueueItem) => BatchQueueItem
+): BatchQueueState {
+  return {
+    ...state,
+    items: state.items.map((item) => (item.id === itemId ? updater(item) : item)),
+  };
+}
+
+function getNeighborSelection(items: BatchQueueItem[], removedIndex: number): string | null {
+  return items[removedIndex]?.id ?? items[removedIndex - 1]?.id ?? null;
+}
+
+export function collectBatchQueueItemCleanupUrls(item: BatchQueueItem): string[] {
+  return item.processedUrl ? [item.originalUrl, item.processedUrl] : [item.originalUrl];
+}
+
+export function createBatchQueueItem(image: ProcessedImage): BatchQueueItem {
+  return {
+    ...image,
+    status: "idle",
+    processResult: null,
+  };
+}
+
+export function createBatchQueueState(items: BatchQueueItem[]): BatchQueueState {
+  return {
+    items,
+    selectedItemId: items[0]?.id ?? null,
+  };
+}
+
+export function appendBatchQueueItems(
+  state: BatchQueueState,
+  items: BatchQueueItem[]
+): BatchQueueState {
+  return {
+    items: [...state.items, ...items],
+    selectedItemId: state.selectedItemId ?? items[0]?.id ?? null,
+  };
+}
+
+export function getSelectedBatchQueueItem(state: BatchQueueState): BatchQueueItem | null {
+  return state.items.find((item) => item.id === state.selectedItemId) ?? null;
+}
+
+export function markBatchQueueItemProcessing(
+  state: BatchQueueState,
+  itemId: string
+): BatchQueueState {
+  return updateBatchQueueItem(state, itemId, (item) => ({
+    ...item,
+    status: "processing",
+    processing: true,
+    error: null,
+  }));
+}
+
+export function markBatchQueueItemSucceeded(
+  state: BatchQueueState,
+  itemId: string,
+  processedUrl: string,
+  processResult: ProcessResult
+): BatchQueueTransitionResult {
+  let cleanupUrls: string[] = [];
+
+  const nextState = updateBatchQueueItem(state, itemId, (item) => {
+    cleanupUrls =
+      item.processedUrl && item.processedUrl !== processedUrl ? [item.processedUrl] : cleanupUrls;
+
+    return {
+      ...item,
+      processedUrl,
+      metadata: {
+        ...item.metadata,
+        ...processResult.metadata,
+      },
+      processing: false,
+      error: null,
+      status: "succeeded",
+      processResult,
+    };
+  });
+
+  return {
+    state: nextState,
+    cleanupUrls,
+  };
+}
+
+export function markBatchQueueItemFailed(
+  state: BatchQueueState,
+  itemId: string,
+  error: string
+): BatchQueueState {
+  return updateBatchQueueItem(state, itemId, (item) => ({
+    ...item,
+    processing: false,
+    error,
+    status: "failed",
+  }));
+}
+
+export function removeBatchQueueItem(
+  state: BatchQueueState,
+  itemId: string
+): BatchQueueTransitionResult {
+  const removedIndex = state.items.findIndex((item) => item.id === itemId);
+  if (removedIndex === -1) {
+    return { state, cleanupUrls: [] };
+  }
+
+  const removedItem = state.items[removedIndex]!;
+  const items = state.items.filter((item) => item.id !== itemId);
+
+  return {
+    state: {
+      items,
+      selectedItemId:
+        state.selectedItemId === itemId
+          ? getNeighborSelection(items, removedIndex)
+          : state.selectedItemId,
+    },
+    cleanupUrls: collectBatchQueueItemCleanupUrls(removedItem),
+  };
+}
+
+export function clearBatchQueueState(state: BatchQueueState): BatchQueueTransitionResult {
+  return {
+    state: {
+      items: [],
+      selectedItemId: null,
+    },
+    cleanupUrls: state.items.flatMap((item) => collectBatchQueueItemCleanupUrls(item)),
+  };
+}

--- a/src/types/batch.ts
+++ b/src/types/batch.ts
@@ -1,0 +1,23 @@
+import type { ProcessedImage } from "./image";
+import type { ProcessResult } from "./processing";
+
+/**
+ * Queue item lifecycle for batch processing.
+ * A single-image session is represented as a queue containing one idle item.
+ */
+export type BatchQueueItemStatus = "idle" | "processing" | "succeeded" | "failed";
+
+export interface BatchQueueItem extends ProcessedImage {
+  status: BatchQueueItemStatus;
+  processResult: ProcessResult | null;
+}
+
+export interface BatchQueueState {
+  items: BatchQueueItem[];
+  selectedItemId: string | null;
+}
+
+export interface BatchQueueTransitionResult {
+  state: BatchQueueState;
+  cleanupUrls: string[];
+}


### PR DESCRIPTION
## Summary
Introduce an explicit batch queue state model so upcoming high-volume workflow work can build on tested state transitions instead of ad hoc component state. The new helpers define queue ordering, selected-item behavior, per-item lifecycle states, and object-URL cleanup rules without changing the current single-image UI.

## Changes
- add documented batch queue types for queue items, lifecycle statuses, and queue transition results
- add a `batchQueueService` with immutable helpers for selection, appending items, processing/success/failure transitions, and cleanup-aware removal/clear operations
- cover queue ordering, single-image subset behavior, failure handling, and cleanup URL rules with focused unit tests

## Testing
- [x] bun run verify
- [x] Run the new `batchQueueService` unit coverage

## References
- Issue: #76
- Fixes #76