### PR TITLE
fix: accessibility baseline for landmarks, controls, and reduced motion

### DIFF
--- a/src/components/shared/AppSelect.test.tsx
+++ b/src/components/shared/AppSelect.test.tsx
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render } from "@solidjs/testing-library";
+import AppSelect from "./AppSelect";
+
+describe("AppSelect", () => {
+  beforeEach(() => {
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: vi.fn(),
+    });
+  });
+
+  it("opens from the trigger and moves keyboard focus into the listbox", async () => {
+    const view = render(() => (
+      <AppSelect
+        id="format-select"
+        options={[
+          { value: "", label: "Keep original" },
+          { value: "image/png", label: "PNG" },
+        ]}
+        value=""
+        onChange={() => {}}
+      />
+    ));
+
+    const trigger = view.container.querySelector("#format-select") as HTMLButtonElement;
+    fireEvent.keyDown(trigger, { key: "ArrowDown" });
+
+    await Promise.resolve();
+
+    const listbox = document.querySelector('[role="listbox"]') as HTMLUListElement;
+
+    expect(trigger).toHaveAttribute("aria-haspopup", "listbox");
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    expect(document.activeElement).toBe(listbox);
+  });
+
+  it("closes on escape and returns focus to the trigger", async () => {
+    const view = render(() => (
+      <AppSelect
+        id="quality-select"
+        options={[
+          { value: "low", label: "Low" },
+          { value: "high", label: "High" },
+        ]}
+        value="low"
+        onChange={() => {}}
+      />
+    ));
+
+    const trigger = view.container.querySelector("#quality-select") as HTMLButtonElement;
+    fireEvent.keyDown(trigger, { key: "ArrowDown" });
+
+    await Promise.resolve();
+
+    const listbox = document.querySelector('[role="listbox"]') as HTMLUListElement;
+    fireEvent.keyDown(listbox, { key: "Escape" });
+
+    expect(document.querySelector('[role="listbox"]')).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+  });
+});

--- a/src/components/shared/AppSelect.tsx
+++ b/src/components/shared/AppSelect.tsx
@@ -80,6 +80,7 @@ export default function AppSelect(props: AppSelectProps) {
     const idx = props.options.findIndex((o) => o.value === props.value);
     setFocusedIndex(idx >= 0 ? idx : (enabledIndices()[0] ?? -1));
     setOpen(true);
+    queueMicrotask(() => listboxRef?.focus());
   }
 
   function closeDropdown() {
@@ -195,7 +196,6 @@ export default function AppSelect(props: AppSelectProps) {
         ref={(el) => (triggerRef = el)}
         type="button"
         id={props.id ?? triggerId}
-        role="combobox"
         aria-haspopup="listbox"
         aria-expanded={open()}
         aria-controls={open() ? listboxId : undefined}

--- a/src/layouts/AppLayout.astro
+++ b/src/layouts/AppLayout.astro
@@ -15,8 +15,8 @@ const { title, description, ogImagePath } = Astro.props;
   <Fragment slot="head">
     <slot name="head" />
   </Fragment>
+  <AppHeader slot="before-main" />
   <div class="flex min-h-[100dvh] flex-col">
-    <AppHeader />
     <div class="flex-1 min-h-0">
       <slot />
     </div>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -69,9 +69,11 @@ const ogImage = new URL(ogImagePath ?? deriveOgImagePath(Astro.url.pathname), As
     >
       Skip to main content
     </a>
+    <slot name="before-main" />
     <main id="main-content">
       <slot />
     </main>
+    <slot name="after-main" />
   </body>
 </html>
 

--- a/src/layouts/MarketingLayout.astro
+++ b/src/layouts/MarketingLayout.astro
@@ -17,9 +17,7 @@ const { title, description, ogImagePath, currentPath = "/" } = Astro.props;
   <Fragment slot="head">
     <slot name="head" />
   </Fragment>
-  <MarketingHeader currentPath={currentPath} />
-  <main>
-    <slot />
-  </main>
-  <MarketingFooter />
+  <MarketingHeader slot="before-main" currentPath={currentPath} />
+  <slot />
+  <MarketingFooter slot="after-main" />
 </Layout>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -13,7 +13,7 @@ import { ROUTES } from "../config/constants";
   <div class="page-pop">
     <FloatingShapes />
 
-    <main class="not-found-main" transition:animate="fade">
+    <div class="not-found-main" transition:animate="fade">
       <div class="not-found-container">
         <div class="not-found-content">
           <span class="not-found-code">404</span>
@@ -40,7 +40,7 @@ import { ROUTES } from "../config/constants";
           </a>
         </div>
       </div>
-    </main>
+    </div>
   </div>
 </MarketingLayout>
 

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -13,7 +13,7 @@ import { GITHUB_URL, ROUTES } from "../config/constants";
   <div class="relative overflow-x-hidden min-h-screen">
     <FloatingShapes />
 
-    <main transition:animate="fade">
+    <div transition:animate="fade">
       <section class="px-8 py-20 text-center relative z-10 md:px-5 md:py-12">
         <div class="max-w-[700px] mx-auto">
           <span class="pop-chip pop-chip-coral">About</span>
@@ -206,7 +206,7 @@ import { GITHUB_URL, ROUTES } from "../config/constants";
           </div>
         </div>
       </section>
-    </main>
+    </div>
   </div>
 </MarketingLayout>
 

--- a/src/pages/changelog/index.astro
+++ b/src/pages/changelog/index.astro
@@ -65,7 +65,7 @@ function formatDate(date: string) {
   <div class="relative overflow-x-hidden min-h-screen">
     <FloatingShapes />
 
-    <main transition:animate="fade">
+    <div transition:animate="fade">
       <section class="px-8 py-20 text-center relative z-10 md:px-5 md:py-12">
         <div class="max-w-[900px] mx-auto">
           <span class="pop-chip pop-chip-mint">Changelog</span>
@@ -127,6 +127,6 @@ function formatDate(date: string) {
           }
         </div>
       </section>
-    </main>
+    </div>
   </div>
 </MarketingLayout>

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -55,7 +55,7 @@ const faqs = [
   <div class="relative overflow-x-hidden min-h-screen">
     <FloatingShapes />
 
-    <main transition:animate="fade">
+    <div transition:animate="fade">
       <section class="px-8 py-20 text-center relative z-10 md:px-5 md:py-12">
         <div class="max-w-[700px] mx-auto">
           <span class="pop-chip pop-chip-yellow">FAQ</span>
@@ -83,10 +83,16 @@ const faqs = [
                 data-reveal
                 data-reveal-delay={i * 60}
               >
-                <button class="faq-question w-full text-left font-display text-[1.05rem] font-semibold py-5 px-6 flex items-center justify-between gap-4 transition-colors duration-200 hover:text-sp-coral">
+                <button
+                  class="faq-question w-full text-left font-display text-[1.05rem] font-semibold py-5 px-6 flex items-center justify-between gap-4 transition-colors duration-200 hover:text-sp-coral"
+                  aria-expanded="false"
+                >
                   {faq.question}
                 </button>
-                <div class="faq-body grid [grid-template-rows:0fr] transition-[grid-template-rows] duration-[400ms] [transition-timing-function:cubic-bezier(0.22,1,0.36,1)]">
+                <div
+                  class="faq-body grid [grid-template-rows:0fr] transition-[grid-template-rows] duration-[400ms] [transition-timing-function:cubic-bezier(0.22,1,0.36,1)]"
+                  role="region"
+                >
                   <div class="overflow-hidden">
                     <p
                       class="faq-answer text-[0.95rem] text-sp-text-muted leading-[1.7] px-6 pb-5 m-0 opacity-0 translate-y-[6px] transition-[opacity,transform] duration-300 delay-[80ms]"
@@ -150,7 +156,7 @@ const faqs = [
           </div>
         </div>
       </section>
-    </main>
+    </div>
   </div>
 </MarketingLayout>
 
@@ -217,7 +223,8 @@ const faqs = [
       if (!question) return;
 
       const toggleItem = () => {
-        item.classList.toggle("faq-open");
+        const isOpen = item.classList.toggle("faq-open");
+        question.setAttribute("aria-expanded", String(isOpen));
       };
 
       question.addEventListener("click", toggleItem);

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -31,7 +31,7 @@ const jsonLd = {
   <div class="relative overflow-x-hidden min-h-screen">
     <FloatingShapes />
 
-    <main transition:animate="fade">
+    <div transition:animate="fade">
       <!-- Hero -->
       <section class="px-8 py-20 text-center relative z-10 md:px-5 md:py-16 md:px-6">
         <div class="max-w-[700px] mx-auto">
@@ -324,6 +324,6 @@ const jsonLd = {
           </a>
         </div>
       </section>
-    </main>
+    </div>
   </div>
 </MarketingLayout>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -12,7 +12,7 @@ import { GITHUB_URL } from "../config/constants";
   <div class="page-pop">
     <FloatingShapes />
 
-    <main transition:animate="fade">
+    <div transition:animate="fade">
       <section class="privacy-hero">
         <div class="privacy-container">
           <span class="pop-chip pop-chip-mint">Privacy</span>
@@ -84,7 +84,7 @@ import { GITHUB_URL } from "../config/constants";
           </div>
         </div>
       </section>
-    </main>
+    </div>
   </div>
 </MarketingLayout>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -94,6 +94,21 @@ html {
   scroll-behavior: smooth;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
 body {
   font-family: var(--sp-font-body);
   background: var(--sp-bg);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,6 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     setupFiles: ["./src/test/setup.ts"],
-    include: ["src/**/*.{test,spec}.{js,ts}"],
+    include: ["src/**/*.{test,spec}.{js,ts,tsx}"],
   },
 });


### PR DESCRIPTION
## Summary
Establish a baseline level of accessibility across the app: correct landmark structure, improved custom control focus management, semantic accordion state, and reduced-motion support.

## Changes
- **Landmarks**: Eliminate nested `<main>` elements by hoisting `Layout.astro`'s `<main>` above header/footer via named slots (`before-main`/`after-main`). All marketing pages now use `<div>` for their content wrapper.
- **AppSelect**: Remove incorrect `role="combobox"` from the trigger (implicit `<button>` is correct), and auto-focus the listbox when opened via `queueMicrotask` for keyboard users.
- **FAQ accordion**: Add `aria-expanded` toggle to each question button and `role="region"` to collapsible answer panels.
- **Reduced motion**: Add `@media (prefers-reduced-motion: reduce)` rule that disables all animations and transitions site-wide.
- **Tests**: Add `AppSelect.test.tsx` covering open/escape focus management. Update `vitest.config.ts` to include `.tsx` test files.

## Testing
- [x] `bun run verify` — 112 tests pass across 11 files
- [x] Manual landmark audit (single `<main id="main-content">` per page)

## References
- Closes #72