### PR TITLE
feat: add rotate and flip transform operations

### DIFF
--- a/src/services/imageService.ts
+++ b/src/services/imageService.ts
@@ -7,6 +7,7 @@ import type {
 } from "../types/processing";
 import { loadImage, resizeOnCanvas, canvasToBlob, getBestFormat } from "./canvasService";
 import { removeBackground } from "./backgroundRemovalService";
+import { rotateImage, flipImage } from "./transformService";
 
 /**
  * Calculate dimensions maintaining aspect ratio
@@ -71,7 +72,20 @@ export async function processImage(
   }
 
   // Step 2: Load image (either original or background-removed)
-  const img = await loadImage(currentFile);
+  let img = await loadImage(currentFile);
+
+  // Step 2.5: Apply transforms (rotate / flip) before resize
+  if (options.transform) {
+    const { rotation, flip } = options.transform;
+    if (rotation) {
+      const rotCanvas = rotateImage(img, rotation);
+      img = await canvasToImageElement(rotCanvas);
+    }
+    if (flip) {
+      const flipCanvas = flipImage(img, flip);
+      img = await canvasToImageElement(flipCanvas);
+    }
+  }
 
   // Step 3: Determine dimensions (resize or original)
   let width = img.width;
@@ -115,6 +129,18 @@ export async function processImage(
       fileSize: blob.size,
     },
   };
+}
+
+/**
+ * Convert a canvas back to an HTMLImageElement so it can be fed into the next step.
+ */
+function canvasToImageElement(canvas: HTMLCanvasElement): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error("Failed to convert canvas to image element"));
+    img.src = canvas.toDataURL();
+  });
 }
 
 /**

--- a/src/services/transformService.test.ts
+++ b/src/services/transformService.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RotationDeg, FlipAxis } from "../types/processing";
+import { flipImage, rotateImage } from "./transformService";
+
+let mockCtx: {
+  save: ReturnType<typeof vi.fn>;
+  restore: ReturnType<typeof vi.fn>;
+  translate: ReturnType<typeof vi.fn>;
+  rotate: ReturnType<typeof vi.fn>;
+  scale: ReturnType<typeof vi.fn>;
+  drawImage: ReturnType<typeof vi.fn>;
+  imageSmoothingEnabled: boolean;
+  imageSmoothingQuality: ImageSmoothingQuality;
+  canvas: HTMLCanvasElement | null;
+};
+
+let createdCanvases: HTMLCanvasElement[];
+
+beforeEach(() => {
+  createdCanvases = [];
+
+  mockCtx = {
+    save: vi.fn(),
+    restore: vi.fn(),
+    translate: vi.fn(),
+    rotate: vi.fn(),
+    scale: vi.fn(),
+    drawImage: vi.fn(),
+    imageSmoothingEnabled: false,
+    imageSmoothingQuality: "high" as ImageSmoothingQuality,
+    canvas: null,
+  };
+
+  vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
+    if (tag !== "canvas") {
+      return document.createElementNS("http://www.w3.org/1999/xhtml", tag) as HTMLElement;
+    }
+
+    // Build a lightweight fake canvas with real width/height properties
+    const fakeCanvas = Object.create(HTMLCanvasElement.prototype) as HTMLCanvasElement;
+    let w = 0;
+    let h = 0;
+    Object.defineProperty(fakeCanvas, "width", {
+      get: () => w,
+      set: (v: number) => {
+        w = v;
+      },
+      configurable: true,
+    });
+    Object.defineProperty(fakeCanvas, "height", {
+      get: () => h,
+      set: (v: number) => {
+        h = v;
+      },
+      configurable: true,
+    });
+    fakeCanvas.getContext = ((contextId: string) => {
+      if (contextId === "2d") {
+        mockCtx.canvas = fakeCanvas;
+        return mockCtx as unknown as CanvasRenderingContext2D;
+      }
+      return null;
+    }) as HTMLCanvasElement["getContext"];
+
+    createdCanvases.push(fakeCanvas);
+    return fakeCanvas;
+  });
+});
+
+function makeImage(w: number, h: number): HTMLImageElement {
+  return { width: w, height: h } as HTMLImageElement;
+}
+
+describe("transformService", () => {
+  describe("rotateImage", () => {
+    it.each<[RotationDeg, number, number]>([
+      [90, 800, 600],
+      [180, 600, 800],
+      [270, 800, 600],
+    ])("rotating by %d° swaps dimensions correctly", (degrees, expectedW, expectedH) => {
+      const canvas = rotateImage(makeImage(600, 800), degrees);
+
+      expect(canvas.width).toBe(expectedW);
+      expect(canvas.height).toBe(expectedH);
+    });
+
+    it("translates to center and rotates by the correct radian angle", () => {
+      rotateImage(makeImage(600, 800), 90);
+
+      // translate(outW/2, outH/2) = translate(400, 300)
+      expect(mockCtx.translate).toHaveBeenCalledWith(400, 300);
+      expect(mockCtx.rotate).toHaveBeenCalledWith((90 * Math.PI) / 180);
+    });
+
+    it("draws the image centered at origin", () => {
+      rotateImage(makeImage(600, 800), 180);
+
+      // translate(outW/2, outH/2) = translate(300, 400)
+      expect(mockCtx.translate).toHaveBeenCalledWith(300, 400);
+      // drawImage(img, -w/2, -h/2, w, h) = drawImage(img, -300, -400, 600, 800)
+      expect(mockCtx.drawImage).toHaveBeenCalledWith(
+        expect.objectContaining({ width: 600, height: 800 }),
+        -300,
+        -400,
+        600,
+        800
+      );
+    });
+  });
+
+  describe("flipImage", () => {
+    it("preserves dimensions", () => {
+      const canvas = flipImage(makeImage(640, 480), "horizontal");
+
+      expect(canvas.width).toBe(640);
+      expect(canvas.height).toBe(480);
+    });
+
+    it.each<FlipAxis>(["horizontal", "vertical"])(
+      "applies correct scale transform for %s flip",
+      (axis) => {
+        flipImage(makeImage(640, 480), axis);
+
+        if (axis === "horizontal") {
+          expect(mockCtx.translate).toHaveBeenCalledWith(640, 0);
+          expect(mockCtx.scale).toHaveBeenCalledWith(-1, 1);
+        } else {
+          expect(mockCtx.translate).toHaveBeenCalledWith(0, 480);
+          expect(mockCtx.scale).toHaveBeenCalledWith(1, -1);
+        }
+      }
+    );
+  });
+});

--- a/src/services/transformService.ts
+++ b/src/services/transformService.ts
@@ -1,0 +1,62 @@
+/**
+ * Rotation and flip transforms for canvas-based image processing.
+ *
+ * All transforms are pure functions that take a source image element and
+ * return a new HTMLCanvasElement with the transform applied.  The caller
+ * is responsible for converting the canvas to the desired output format.
+ */
+import type { RotationDeg, FlipAxis } from "../types/processing";
+import { resizeOnCanvas } from "./canvasService";
+
+/**
+ * Rotate a source image by a multiple of 90° clockwise.
+ *
+ * 90° and 270° swaps the output width and height.
+ * 180° preserves them.
+ */
+export function rotateImage(img: HTMLImageElement, degrees: RotationDeg): HTMLCanvasElement {
+  const { width, height } = img;
+  const swap = degrees === 90 || degrees === 270;
+  const outW = swap ? height : width;
+  const outH = swap ? width : height;
+
+  const canvas = document.createElement("canvas");
+  canvas.width = outW;
+  canvas.height = outH;
+
+  const ctx = canvas.getContext("2d")!;
+  ctx.imageSmoothingEnabled = true;
+  ctx.imageSmoothingQuality = "high";
+
+  ctx.save();
+  ctx.translate(outW / 2, outH / 2);
+  ctx.rotate((degrees * Math.PI) / 180);
+  ctx.drawImage(img, -width / 2, -height / 2, width, height);
+  ctx.restore();
+
+  return canvas;
+}
+
+/**
+ * Flip (mirror) a source image along the given axis.
+ *
+ * Dimensions are preserved.
+ */
+export function flipImage(img: HTMLImageElement, axis: FlipAxis): HTMLCanvasElement {
+  // Reuse resizeOnCanvas for a simple 1:1 copy first
+  const copy = resizeOnCanvas(img, img.width, img.height);
+  const ctx = copy.getContext("2d")!;
+
+  ctx.save();
+  if (axis === "horizontal") {
+    ctx.translate(copy.width, 0);
+    ctx.scale(-1, 1);
+  } else {
+    ctx.translate(0, copy.height);
+    ctx.scale(1, -1);
+  }
+  ctx.drawImage(copy, 0, 0);
+  ctx.restore();
+
+  return copy;
+}

--- a/src/types/processing.ts
+++ b/src/types/processing.ts
@@ -15,6 +15,24 @@ export interface ResizeOptions {
 }
 
 /**
+ * Rotation angle in degrees (clockwise).
+ */
+export type RotationDeg = 90 | 180 | 270;
+
+/**
+ * Axis along which to mirror the image.
+ */
+export type FlipAxis = "horizontal" | "vertical";
+
+/**
+ * Transform options applied before resize/format operations.
+ */
+export interface TransformOptions {
+  rotation?: RotationDeg;
+  flip?: FlipAxis;
+}
+
+/**
  * Complete options for processing an image
  * Combines resize, format conversion, and compression
  */
@@ -23,6 +41,7 @@ export interface ProcessOptions {
   format?: ImageFormat;
   quality?: number; // 0-1 range for compression quality
   removeBackground?: boolean;
+  transform?: TransformOptions;
 }
 
 /**


### PR DESCRIPTION
## Summary
Add canvas-based rotate and flip transforms as a new processing pipeline step. These transforms are applied after load and before resize/format operations, enabling essential image orientation corrections.

## Changes
- **transformService**: New service with `rotateImage` (90°/180°/270° clockwise) and `flipImage` (horizontal/vertical) as pure canvas-based functions
- **TransformOptions type**: New type (`rotation` + `flip`) added to processing types and integrated into `ProcessOptions`
- **Pipeline integration**: Transforms are applied in `processImage` between load and resize steps via `canvasToImageElement` helper
- **Tests**: 8 unit tests covering dimension correctness, transform math (translate/rotate/scale calls), and axis behavior

## Testing
- [x] `bun run verify` — 120 tests pass across 12 files
- [x] Dimension swap correctness verified for all rotation angles
- [x] Transform call parameters verified (translate, rotate, scale)

## References
- Closes #24