### PR TITLE
feat: add target file size export mode

### DIFF
--- a/src/services/imageService.ts
+++ b/src/services/imageService.ts
@@ -9,6 +9,7 @@ import { loadImage, resizeOnCanvas, canvasToBlob, getBestFormat } from "./canvas
 import { removeBackground } from "./backgroundRemovalService";
 import { rotateImage, flipImage } from "./transformService";
 import { decodeHeicBlob, isHeicInput } from "./formatDetectionService";
+import { compressToTargetSize, formatSupportsQuality } from "./targetSizeService";
 
 /**
  * Calculate dimensions maintaining aspect ratio
@@ -127,7 +128,17 @@ export async function processImage(
   }
 
   // Step 7: Convert to blob
-  const blob = await canvasToBlob(canvas, format, quality);
+  let blob: Blob;
+
+  if (options.targetFileSize && formatSupportsQuality(format)) {
+    const sizeResult = await compressToTargetSize(
+      { canvas, format, targetBytes: options.targetFileSize },
+      canvasToBlob
+    );
+    blob = sizeResult.blob;
+  } else {
+    blob = await canvasToBlob(canvas, format, quality);
+  }
 
   return {
     blob,

--- a/src/services/targetSizeService.test.ts
+++ b/src/services/targetSizeService.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ImageFormat } from "../types/image";
+import type { CanvasEncoder } from "./targetSizeService";
+import { compressToTargetSize, formatSupportsQuality } from "./targetSizeService";
+
+describe("targetSizeService", () => {
+  describe("formatSupportsQuality", () => {
+    it.each<{ format: ImageFormat; expected: boolean }>([
+      { format: "image/jpeg", expected: true },
+      { format: "image/webp", expected: true },
+      { format: "image/png", expected: false },
+      { format: "image/avif", expected: false },
+      { format: "image/gif", expected: false },
+    ])("returns $expected for $format", ({ format, expected }) => {
+      expect(formatSupportsQuality(format)).toBe(expected);
+    });
+  });
+
+  describe("compressToTargetSize", () => {
+    const mockCanvas = {} as HTMLCanvasElement;
+
+    it("returns the blob as-is for PNG with hitTarget based on actual size", async () => {
+      const encode = vi
+        .fn<CanvasEncoder>()
+        .mockResolvedValue(new Blob(["x".repeat(500)], { type: "image/png" }));
+
+      const result = await compressToTargetSize(
+        { canvas: mockCanvas, format: "image/png", targetBytes: 1000 },
+        encode
+      );
+
+      expect(result.hitTarget).toBe(true);
+      expect(result.quality).toBe(1);
+      expect(encode).toHaveBeenCalledOnce();
+    });
+
+    it("reports hitTarget=false for PNG exceeding the target", async () => {
+      const encode = vi
+        .fn<CanvasEncoder>()
+        .mockResolvedValue(new Blob(["x".repeat(2000)], { type: "image/png" }));
+
+      const result = await compressToTargetSize(
+        { canvas: mockCanvas, format: "image/png", targetBytes: 500 },
+        encode
+      );
+
+      expect(result.hitTarget).toBe(false);
+    });
+
+    it("finds a quality that fits within the target for JPEG", async () => {
+      // Simulate: size scales linearly with quality
+      const encode = vi.fn<CanvasEncoder>().mockImplementation((_c, _f, q = 1) => {
+        const size = Math.round(2000 * q);
+        return Promise.resolve(new Blob(["x".repeat(size)], { type: "image/jpeg" }));
+      });
+
+      const result = await compressToTargetSize(
+        { canvas: mockCanvas, format: "image/jpeg", targetBytes: 1500 },
+        encode
+      );
+
+      expect(result.hitTarget).toBe(true);
+      expect(result.quality).toBeGreaterThan(0);
+      expect(result.blob.size).toBeLessThanOrEqual(1500);
+    });
+
+    it("returns the floor quality blob when target is unachievable", async () => {
+      // Every quality level produces a blob larger than target
+      const encode = vi.fn<CanvasEncoder>().mockImplementation((_c, _f, q = 1) => {
+        const size = Math.round(5000 * q + 1000); // always >= 1000
+        return Promise.resolve(new Blob(["x".repeat(size)], { type: "image/jpeg" }));
+      });
+
+      const result = await compressToTargetSize(
+        { canvas: mockCanvas, format: "image/jpeg", targetBytes: 500, minQuality: 0.2 },
+        encode
+      );
+
+      expect(result.hitTarget).toBe(false);
+      expect(result.quality).toBe(0.2);
+    });
+
+    it("respects the maxIterations limit", async () => {
+      const encode = vi
+        .fn<CanvasEncoder>()
+        .mockResolvedValue(new Blob(["x".repeat(100)], { type: "image/webp" }));
+
+      await compressToTargetSize(
+        { canvas: mockCanvas, format: "image/webp", targetBytes: 50, maxIterations: 3 },
+        encode
+      );
+
+      // Binary search: up to maxIterations + possible floor fallback
+      expect(encode.mock.calls.length).toBeLessThanOrEqual(5);
+    });
+  });
+});

--- a/src/services/targetSizeService.ts
+++ b/src/services/targetSizeService.ts
@@ -1,0 +1,110 @@
+/**
+ * Target file size export mode.
+ *
+ * Given a canvas, output format, and a byte ceiling, iteratively compress
+ * until the result fits or the quality floor is exhausted.  The algorithm
+ * uses a binary search over the quality parameter for efficiency.
+ *
+ * PNG is always lossless — the function reports hitTarget=false when the
+ * natural PNG output exceeds the target.
+ */
+import type { ImageFormat } from "../types/image";
+
+export interface TargetFileSizeResult {
+  blob: Blob;
+  quality: number;
+  hitTarget: boolean;
+}
+
+export interface TargetFileSizeOptions {
+  canvas: HTMLCanvasElement;
+  format: ImageFormat;
+  targetBytes: number;
+  /** Quality floor — stop iterating below this (0-1). Default 0.1 */
+  minQuality?: number;
+  /** Maximum iterations. Default 10 */
+  maxIterations?: number;
+}
+
+/**
+ * Injected canvas-to-blob function for testability.
+ * Production callers pass the real `canvasToBlob` from canvasService.
+ */
+export type CanvasEncoder = (
+  canvas: HTMLCanvasElement,
+  format: ImageFormat,
+  quality?: number
+) => Promise<Blob>;
+
+const FORMATS_WITH_QUALITY: ReadonlySet<ImageFormat> = new Set(["image/jpeg", "image/webp"]);
+
+/**
+ * Check whether the given format supports quality-based compression.
+ */
+export function formatSupportsQuality(format: ImageFormat): boolean {
+  return FORMATS_WITH_QUALITY.has(format);
+}
+
+/**
+ * Iteratively compress a canvas toward a target file size.
+ *
+ * Uses binary search between 1.0 and minQuality to find the best quality
+ * that fits within targetBytes.
+ *
+ * Returns `{ hitTarget: false }` when even minQuality exceeds the target.
+ */
+export async function compressToTargetSize(
+  options: TargetFileSizeOptions,
+  encode: CanvasEncoder
+): Promise<TargetFileSizeResult> {
+  const { canvas, format, targetBytes, minQuality = 0.1, maxIterations = 10 } = options;
+
+  // For formats without quality control, just encode and compare
+  if (!formatSupportsQuality(format)) {
+    const blob = await encode(canvas, format);
+    return {
+      blob,
+      quality: 1,
+      hitTarget: blob.size <= targetBytes,
+    };
+  }
+
+  let low = minQuality;
+  let high = 1.0;
+  let bestBlob: Blob | null = null;
+  let bestQuality = 0;
+
+  for (let i = 0; i < maxIterations; i++) {
+    const mid = Math.round(((low + high) / 2) * 100) / 100;
+    const blob = await encode(canvas, format, mid);
+
+    if (blob.size <= targetBytes) {
+      bestBlob = blob;
+      bestQuality = mid;
+      // Try higher quality — we have room
+      low = mid;
+    } else {
+      // Too large — try lower quality
+      high = mid;
+    }
+
+    // Converged when range is narrower than 1% quality
+    if (high - low < 0.01) break;
+  }
+
+  // If we never found a fit, use the lowest quality attempt
+  if (!bestBlob) {
+    const floorBlob = await encode(canvas, format, minQuality);
+    return {
+      blob: floorBlob,
+      quality: minQuality,
+      hitTarget: floorBlob.size <= targetBytes,
+    };
+  }
+
+  return {
+    blob: bestBlob,
+    quality: bestQuality,
+    hitTarget: true,
+  };
+}

--- a/src/types/processing.ts
+++ b/src/types/processing.ts
@@ -42,6 +42,7 @@ export interface ProcessOptions {
   quality?: number; // 0-1 range for compression quality
   removeBackground?: boolean;
   transform?: TransformOptions;
+  targetFileSize?: number; // target output size in bytes
 }
 
 /**


### PR DESCRIPTION
## Summary
Add a target file size export mode that uses binary search over the quality parameter to produce output within a user-specified byte ceiling. Only applies to formats that support quality-based compression (JPEG/WebP).

## Changes
- **targetSizeService**: New service with `compressToTargetSize` (binary search between 1.0 and configurable min quality floor), `formatSupportsQuality` gating, and injected `CanvasEncoder` for testability
- **ProcessOptions**: Added `targetFileSize` field (bytes) — mutually exclusive with manual quality
- **Pipeline integration**: `processImage` delegates to `compressToTargetSize` when `targetFileSize` is set and format supports quality
- **Tests**: 10 unit tests covering format gating, binary search convergence, unachievable targets, PNG passthrough, and iteration limits

## Testing
- [x] `bun run verify` — 153 tests pass across 14 files
- [x] Binary search converges correctly for linear quality-to-size mapping
- [x] Floor quality fallback when target is unreachable

## References
- Closes #29