### PR TITLE
feat: add image adjustments (brightness, contrast, saturation)

### DIFF
--- a/src/services/adjustmentService.test.ts
+++ b/src/services/adjustmentService.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import type { ImageAdjustments } from "../types/processing";
+import { buildFilterString, DEFAULT_ADJUSTMENTS, isNoOpAdjustments } from "./adjustmentService";
+
+describe("adjustmentService", () => {
+  describe("DEFAULT_ADJUSTMENTS", () => {
+    it("has all values set to 1 (no-op)", () => {
+      expect(DEFAULT_ADJUSTMENTS).toEqual({
+        brightness: 1,
+        contrast: 1,
+        saturation: 1,
+      });
+    });
+  });
+
+  describe("isNoOpAdjustments", () => {
+    it.each<{ adj: ImageAdjustments | undefined; expected: boolean }>([
+      { adj: undefined, expected: true },
+      { adj: {}, expected: true },
+      { adj: { brightness: 1, contrast: 1, saturation: 1 }, expected: true },
+      { adj: { brightness: 1 }, expected: true },
+      { adj: { brightness: 1.5 }, expected: false },
+      { adj: { contrast: 0.8 }, expected: false },
+      { adj: { saturation: 2 }, expected: false },
+      { adj: { brightness: 1, contrast: 1, saturation: 1.5 }, expected: false },
+    ])("returns $expected for $adj", ({ adj, expected }) => {
+      expect(isNoOpAdjustments(adj)).toBe(expected);
+    });
+  });
+
+  describe("buildFilterString", () => {
+    it("returns empty string for no-op adjustments", () => {
+      expect(buildFilterString({})).toBe("");
+      expect(buildFilterString({ brightness: 1, contrast: 1, saturation: 1 })).toBe("");
+    });
+
+    it("builds a brightness-only filter", () => {
+      expect(buildFilterString({ brightness: 1.5 })).toBe("brightness(1.5)");
+    });
+
+    it("builds a contrast-only filter", () => {
+      expect(buildFilterString({ contrast: 0.7 })).toBe("contrast(0.7)");
+    });
+
+    it("builds a saturation-only filter", () => {
+      expect(buildFilterString({ saturation: 2 })).toBe("saturate(2)");
+    });
+
+    it("combines multiple adjustments in order", () => {
+      const result = buildFilterString({ brightness: 1.2, contrast: 0.8, saturation: 1.5 });
+
+      expect(result).toBe("brightness(1.2) contrast(0.8) saturate(1.5)");
+    });
+
+    it("omits neutral values from the combined filter", () => {
+      const result = buildFilterString({ brightness: 1, contrast: 1.5, saturation: 1 });
+
+      expect(result).toBe("contrast(1.5)");
+    });
+  });
+});

--- a/src/services/adjustmentService.ts
+++ b/src/services/adjustmentService.ts
@@ -1,0 +1,39 @@
+import type { ImageAdjustments } from "../types/processing";
+
+/** The neutral / no-op adjustment values. */
+export const DEFAULT_ADJUSTMENTS: Required<ImageAdjustments> = {
+  brightness: 1,
+  contrast: 1,
+  saturation: 1,
+};
+
+/**
+ * Check whether an adjustments object represents a no-op
+ * (all values are at their defaults or undefined).
+ */
+export function isNoOpAdjustments(adj: ImageAdjustments | undefined): boolean {
+  if (!adj) return true;
+  return (adj.brightness ?? 1) === 1 && (adj.contrast ?? 1) === 1 && (adj.saturation ?? 1) === 1;
+}
+
+/**
+ * Build a CSS filter string from the given adjustments.
+ *
+ * Returns an empty string for no-op adjustments.
+ */
+export function buildFilterString(adj: ImageAdjustments): string {
+  if (isNoOpAdjustments(adj)) return "";
+
+  const parts: string[] = [];
+
+  const brightness = adj.brightness ?? 1;
+  if (brightness !== 1) parts.push(`brightness(${brightness})`);
+
+  const contrast = adj.contrast ?? 1;
+  if (contrast !== 1) parts.push(`contrast(${contrast})`);
+
+  const saturation = adj.saturation ?? 1;
+  if (saturation !== 1) parts.push(`saturate(${saturation})`);
+
+  return parts.join(" ");
+}

--- a/src/services/imageService.ts
+++ b/src/services/imageService.ts
@@ -10,6 +10,7 @@ import { removeBackground } from "./backgroundRemovalService";
 import { rotateImage, flipImage } from "./transformService";
 import { decodeHeicBlob, isHeicInput } from "./formatDetectionService";
 import { compressToTargetSize, formatSupportsQuality } from "./targetSizeService";
+import { buildFilterString, isNoOpAdjustments } from "./adjustmentService";
 
 /**
  * Calculate dimensions maintaining aspect ratio
@@ -109,6 +110,17 @@ export async function processImage(
 
   // Step 4: Create canvas with final dimensions
   const canvas = resizeOnCanvas(img, width, height);
+
+  // Step 4.5: Apply image adjustments (brightness, contrast, saturation)
+  if (options.adjustments && !isNoOpAdjustments(options.adjustments)) {
+    const filterStr = buildFilterString(options.adjustments);
+    const adjCtx = canvas.getContext("2d");
+    if (adjCtx && filterStr) {
+      adjCtx.filter = filterStr;
+      adjCtx.drawImage(canvas, 0, 0);
+      adjCtx.filter = "none";
+    }
+  }
 
   // Step 5: Determine format (convert or original)
   // If background removal is enabled, force PNG to preserve transparency

--- a/src/types/processing.ts
+++ b/src/types/processing.ts
@@ -33,6 +33,18 @@ export interface TransformOptions {
 }
 
 /**
+ * Image adjustment controls. Default values (1) produce no-op output.
+ */
+export interface ImageAdjustments {
+  /** 0 = black, 1 = unchanged, 2 = twice as bright */
+  brightness?: number;
+  /** 0 = gray, 1 = unchanged, 2 = high contrast */
+  contrast?: number;
+  /** 0 = desaturated, 1 = unchanged, 2 = oversaturated */
+  saturation?: number;
+}
+
+/**
  * Complete options for processing an image
  * Combines resize, format conversion, and compression
  */
@@ -43,6 +55,7 @@ export interface ProcessOptions {
   removeBackground?: boolean;
   transform?: TransformOptions;
   targetFileSize?: number; // target output size in bytes
+  adjustments?: ImageAdjustments;
 }
 
 /**


### PR DESCRIPTION
## Summary
Add brightness, contrast, and saturation adjustment controls as a canvas CSS filter pipeline step. Default values (1) produce pixel-identical output; non-default values are applied after resize and before format conversion.

## Changes
- **ImageAdjustments type**: New interface in processing types with `brightness`, `contrast`, `saturation` (all default 1)
- **adjustmentService**: New service with `isNoOpAdjustments` guard and `buildFilterString` for CSS canvas filter generation
- **Pipeline integration**: Applied in `processImage` via `ctx.filter` after resize, before format conversion
- **Tests**: 15 unit tests covering no-op detection, single/combined filter strings, and neutral value omission

## Testing
- [x] `bun run verify` — 168 tests pass across 15 files
- [x] All no-op cases produce empty filter string
- [x] Combined filters preserve order and omit neutrals

## References
- Closes #28