### PR TITLE
feat: add export recipes for common output constraints

### DIFF
--- a/src/services/exportRecipeService.test.ts
+++ b/src/services/exportRecipeService.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import type { ProcessOptions } from "../types/processing";
+import { applyRecipe, EXPORT_RECIPES, getRecipeById } from "./exportRecipeService";
+
+describe("exportRecipeService", () => {
+  describe("EXPORT_RECIPES", () => {
+    it("provides at least 6 built-in recipes", () => {
+      expect(EXPORT_RECIPES.length).toBeGreaterThanOrEqual(6);
+    });
+
+    it("has unique stable IDs for every recipe", () => {
+      const ids = EXPORT_RECIPES.map((r) => r.id);
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it("every recipe has a label, description, and options", () => {
+      for (const recipe of EXPORT_RECIPES) {
+        expect(recipe.label).toBeTruthy();
+        expect(recipe.description).toBeTruthy();
+        expect(recipe.options).toBeDefined();
+      }
+    });
+  });
+
+  describe("getRecipeById", () => {
+    it("finds a recipe by its ID", () => {
+      const recipe = getRecipeById("email-under-500k");
+      expect(recipe).toBeDefined();
+      expect(recipe!.label).toBe("Email-ready");
+    });
+
+    it("returns undefined for unknown IDs", () => {
+      expect(getRecipeById("does-not-exist")).toBeUndefined();
+    });
+  });
+
+  describe("applyRecipe", () => {
+    it("merges recipe options on top of current settings", () => {
+      const current: ProcessOptions = {
+        quality: 0.5,
+        resize: { width: 800, height: 600, maintainAspectRatio: false },
+      };
+
+      const result = applyRecipe(current, getRecipeById("social-post")!);
+
+      expect(result.format).toBe("image/jpeg");
+      expect(result.quality).toBe(0.85);
+      // Recipe resize replaces width but inherits maintainAspectRatio from deep merge
+      expect(result.resize).toEqual({
+        width: 1200,
+        height: 600,
+        maintainAspectRatio: true,
+      });
+    });
+
+    it("preserves current options not overridden by the recipe", () => {
+      const current: ProcessOptions = {
+        format: "image/png",
+        quality: 0.9,
+        removeBackground: true,
+      };
+
+      const result = applyRecipe(current, getRecipeById("thumbnail")!);
+
+      // Recipe overrides format and quality but not removeBackground
+      expect(result.format).toBe("image/jpeg");
+      expect(result.quality).toBe(0.7);
+      expect(result.removeBackground).toBe(true);
+    });
+
+    it("deep-merges resize options without losing existing fields", () => {
+      const current: ProcessOptions = {
+        resize: { width: 2000, height: 1500, maintainAspectRatio: true },
+      };
+
+      const result = applyRecipe(current, getRecipeById("web-optimized")!);
+
+      expect(result.resize).toEqual({
+        width: 1000,
+        height: 1500,
+        maintainAspectRatio: true,
+      });
+    });
+  });
+});

--- a/src/services/exportRecipeService.ts
+++ b/src/services/exportRecipeService.ts
@@ -1,0 +1,105 @@
+/**
+ * Export recipes — predefined processing configurations for common outcomes.
+ *
+ * Each recipe maps directly to existing ProcessOptions fields with no hidden
+ * behaviour.  Users can inspect and tweak the resulting settings after
+ * applying a recipe.
+ */
+import type { ProcessOptions } from "../types/processing";
+
+export interface ExportRecipe {
+  id: string;
+  label: string;
+  description: string;
+  /** Partial ProcessOptions to merge into the current settings */
+  options: Partial<ProcessOptions>;
+}
+
+/**
+ * Built-in recipes.  IDs are stable so they can be referenced from URL
+ * params or keyboard shortcuts later.
+ */
+export const EXPORT_RECIPES: readonly ExportRecipe[] = [
+  {
+    id: "email-under-500k",
+    label: "Email-ready",
+    description: "JPEG under 500 KB for email attachments",
+    options: {
+      format: "image/jpeg",
+      quality: 0.8,
+      targetFileSize: 512_000,
+      resize: { width: 1600, maintainAspectRatio: true },
+    },
+  },
+  {
+    id: "social-post",
+    label: "Social post",
+    description: "1200 px wide JPEG, good quality",
+    options: {
+      format: "image/jpeg",
+      quality: 0.85,
+      resize: { width: 1200, maintainAspectRatio: true },
+    },
+  },
+  {
+    id: "web-optimized",
+    label: "Web optimized",
+    description: "WebP, 1000 px wide, compressed for fast loading",
+    options: {
+      format: "image/webp",
+      quality: 0.75,
+      resize: { width: 1000, maintainAspectRatio: true },
+    },
+  },
+  {
+    id: "thumbnail",
+    label: "Thumbnail",
+    description: "300 px wide JPEG, small file",
+    options: {
+      format: "image/jpeg",
+      quality: 0.7,
+      resize: { width: 300, maintainAspectRatio: true },
+    },
+  },
+  {
+    id: "transparent-png",
+    label: "Transparent PNG",
+    description: "Background removed, PNG with transparency",
+    options: {
+      format: "image/png",
+      removeBackground: true,
+    },
+  },
+  {
+    id: "original-quality",
+    label: "Original quality",
+    description: "Minimal processing, preserve original dimensions",
+    options: {
+      quality: 0.95,
+    },
+  },
+];
+
+/**
+ * Look up a recipe by stable ID.
+ */
+export function getRecipeById(id: string): ExportRecipe | undefined {
+  return EXPORT_RECIPES.find((r) => r.id === id);
+}
+
+/**
+ * Apply a recipe's options on top of existing settings.
+ *
+ * Recipe values take precedence, but undefined fields in the recipe
+ * preserve the user's existing choices.
+ */
+export function applyRecipe(current: ProcessOptions, recipe: ExportRecipe): ProcessOptions {
+  return {
+    ...current,
+    ...recipe.options,
+    // Deep-merge resize so partial resize overrides don't lose existing fields
+    resize: recipe.options.resize
+      ? { ...current.resize, ...recipe.options.resize }
+      : current.resize,
+  };
+}


### PR DESCRIPTION
## Summary
Add a set of built-in export recipes that map directly to ProcessOptions, making common workflows like "email under 500 KB" or "social post" one-click operations. Recipes are transparent — users can inspect and tweak settings after applying.

## Changes
- **exportRecipeService**: New service with 6 built-in recipes (email-ready, social-post, web-optimized, thumbnail, transparent-png, original-quality), `getRecipeById` lookup, and `applyRecipe` that deep-merges recipe options on top of current settings
- **Tests**: 8 unit tests covering recipe integrity (unique IDs, required fields), lookup, merge precedence, and resize deep-merge behavior

## Testing
- [x] `bun run verify` — 176 tests pass across 16 files
- [x] All recipes have unique stable IDs, labels, and descriptions
- [x] Deep-merge preserves user choices not overridden by the recipe

## References
- Closes #80