### PR TITLE
refactor: componentize all marketing pages into reusable components

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -19,3 +19,12 @@ yarn.lock
 
 # Release Please output
 CHANGELOG.md
+
+# Agent-generated files
+PLAN.md
+IMPROVE.md
+REVIEW.md
+INVESTIGATION.md
+
+# Test artifacts
+test-results/

--- a/bun.lock
+++ b/bun.lock
@@ -21,6 +21,7 @@
         "@commitlint/cli": "^20.5.3",
         "@commitlint/config-conventional": "^20.5.3",
         "@eslint/js": "^10.0.1",
+        "@playwright/test": "^1.59.1",
         "@solidjs/testing-library": "^0.8.10",
         "@tailwindcss/vite": "^4.2.4",
         "@testing-library/jest-dom": "^6.9.1",
@@ -480,6 +481,8 @@
     "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
 
     "@pkgr/core": ["@pkgr/core@0.2.9", "", {}, "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA=="],
+
+    "@playwright/test": ["@playwright/test@1.59.1", "", { "dependencies": { "playwright": "1.59.1" }, "bin": { "playwright": "cli.js" } }, "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg=="],
 
     "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
 
@@ -1637,6 +1640,10 @@
 
     "platform": ["platform@1.3.6", "", {}, "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="],
 
+    "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
+
+    "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
+
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
     "postcss": ["postcss@8.5.13", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag=="],
@@ -2220,6 +2227,8 @@
     "p-locate/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
     "parse5/entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "randombytes/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 

--- a/e2e/marketing-pages.spec.ts
+++ b/e2e/marketing-pages.spec.ts
@@ -1,12 +1,12 @@
 import { test, expect } from "@playwright/test";
 
-const ROUTES = [
+const ROUTES: { path: string; title: RegExp; navPath?: string }[] = [
   { path: "/", title: /Your images deserve/i },
-  { path: "/features", title: /Everything you need/i },
-  { path: "/about", title: /Built for privacy/i },
-  { path: "/faq", title: /Frequently asked questions/i },
-  { path: "/privacy", title: /Your images never leave/i },
-  { path: "/changelog", title: /What.s new in Reshrimp/i },
+  { path: "/features", title: /Everything you need/i, navPath: "/features" },
+  { path: "/about", title: /Built for privacy/i, navPath: "/about" },
+  { path: "/faq", title: /Frequently asked questions/i, navPath: "/faq" },
+  { path: "/privacy", title: /Your images never leave/i, navPath: "/privacy" },
+  { path: "/changelog", title: /What.s new in Reshrimp/i, navPath: "/changelog" },
   { path: "/404", title: /Page not found/i },
 ];
 
@@ -26,4 +26,51 @@ test.describe("Marketing pages", () => {
       await expect(page.getByText(route.title).first()).toBeVisible();
     });
   }
+
+  test("navigation links work between marketing pages", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    // Click each nav link and verify the page changes
+    const navLinks = [
+      { text: "Home", path: "/" },
+      { text: "Features", path: "/features" },
+      { text: "About", path: "/about" },
+      { text: "FAQ", path: "/faq" },
+      { text: "Privacy", path: "/privacy" },
+    ];
+
+    for (const link of navLinks) {
+      // Click the nav link
+      const navLink = page.locator("nav a", { hasText: link.text }).first();
+      if (await navLink.isVisible()) {
+        await navLink.click();
+        await page.waitForLoadState("networkidle");
+        await expect(page).toHaveURL(new RegExp(link.path));
+      }
+    }
+  });
+
+  test.describe("mobile navigation", () => {
+    test.use({ viewport: { width: 375, height: 812 } });
+
+    test("burger menu opens and closes", async ({ page }) => {
+      await page.goto("/");
+      await page.waitForLoadState("networkidle");
+
+      // Find the mobile menu toggle button
+      const menuButton = page
+        .locator("button[aria-label*=menu], button[aria-label*=Menu], nav button")
+        .first();
+      if (await menuButton.isVisible()) {
+        // Open menu
+        await menuButton.click();
+        await page.waitForTimeout(300);
+
+        // Close menu (click again)
+        await menuButton.click();
+        await page.waitForTimeout(300);
+      }
+    });
+  });
 });

--- a/e2e/marketing-pages.spec.ts
+++ b/e2e/marketing-pages.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from "@playwright/test";
+
+const ROUTES = [
+  { path: "/", title: /Your images deserve/i },
+  { path: "/features", title: /Everything you need/i },
+  { path: "/about", title: /Built for privacy/i },
+  { path: "/faq", title: /Frequently asked questions/i },
+  { path: "/privacy", title: /Your images never leave/i },
+  { path: "/changelog", title: /What.s new in Reshrimp/i },
+  { path: "/404", title: /Page not found/i },
+];
+
+test.describe("Marketing pages", () => {
+  for (const route of ROUTES) {
+    test(`page loads: ${route.path}`, async ({ page }) => {
+      const errors: string[] = [];
+      page.on("pageerror", (err) => errors.push(err.message));
+
+      await page.goto(route.path);
+      await page.waitForLoadState("networkidle");
+
+      // No console errors
+      expect(errors).toEqual([]);
+
+      // Hero title is visible
+      await expect(page.getByText(route.title).first()).toBeVisible();
+    });
+  }
+});

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@commitlint/cli": "^20.5.3",
     "@commitlint/config-conventional": "^20.5.3",
     "@eslint/js": "^10.0.1",
+    "@playwright/test": "^1.59.1",
     "@solidjs/testing-library": "^0.8.10",
     "@tailwindcss/vite": "^4.2.4",
     "@testing-library/jest-dom": "^6.9.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  /* Run tests in dev server */
+  webServer: {
+    command: "bun run dev --port 4322",
+    port: 4322,
+    reuseExistingServer: !process.env.CI,
+    timeout: 30000,
+  },
+  use: {
+    baseURL: "http://localhost:4322",
+  },
+});

--- a/src/components/marketing/cards/AboutCard.astro
+++ b/src/components/marketing/cards/AboutCard.astro
@@ -1,0 +1,17 @@
+---
+interface Props {
+  children: unknown;
+  delay?: number;
+  class?: string;
+}
+
+const { delay = 0, class: className } = Astro.props;
+---
+
+<div
+  class:list={["bg-sp-bg-card border border-sp-border rounded-sp-xl p-8 shadow-sp mb-6", className]}
+  data-reveal
+  data-reveal-delay={String(delay)}
+>
+  <slot />
+</div>

--- a/src/components/marketing/cards/PrivacyCard.astro
+++ b/src/components/marketing/cards/PrivacyCard.astro
@@ -1,0 +1,7 @@
+---
+
+---
+
+<div class="bg-sp-bg-card border border-sp-border rounded-sp-xl p-8 shadow-sp mb-6">
+  <slot />
+</div>

--- a/src/components/marketing/cards/TechStackGrid.astro
+++ b/src/components/marketing/cards/TechStackGrid.astro
@@ -1,0 +1,7 @@
+---
+
+---
+
+<div class="grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] gap-4">
+  <slot />
+</div>

--- a/src/components/marketing/cards/TechStackItem.astro
+++ b/src/components/marketing/cards/TechStackItem.astro
@@ -1,0 +1,12 @@
+---
+interface Props {
+  name: string;
+  description: string;
+}
+const { name, description } = Astro.props;
+---
+
+<div class="bg-sp-bg border border-sp-border-light rounded-sp p-4 flex flex-col gap-1">
+  <span class="font-display font-semibold text-[0.95rem]">{name}</span>
+  <span class="text-[0.8rem] text-sp-text-soft">{description}</span>
+</div>

--- a/src/components/marketing/hero/HeroCTA.astro
+++ b/src/components/marketing/hero/HeroCTA.astro
@@ -1,0 +1,29 @@
+---
+import { ArrowRight } from "lucide-astro";
+import { makeHref } from "../../../lib/utils";
+import { ROUTES } from "../../../config/constants";
+
+interface Props {
+  href?: string;
+  label?: string;
+  secondaryText?: string;
+  size?: "default" | "lg";
+}
+const {
+  href = makeHref(ROUTES.APP),
+  label = "Start processing",
+  secondaryText,
+  size = "default",
+} = Astro.props;
+---
+
+<div
+  class="flex flex-col items-center gap-3 opacity-0"
+  style="animation: popBounceIn 0.6s 0.55s forwards"
+>
+  <a href={href} class:list={["cta-pop", { "cta-pop-lg": size === "lg" }]}>
+    {label}
+    <ArrowRight size={18} strokeWidth={2} class="cta-pop-arrow" />
+  </a>
+  {secondaryText ? <span class="text-[0.8rem] text-sp-text-soft">{secondaryText}</span> : null}
+</div>

--- a/src/components/marketing/hero/HeroSection.astro
+++ b/src/components/marketing/hero/HeroSection.astro
@@ -1,0 +1,76 @@
+---
+interface Chip {
+  label: string;
+  variant: "coral" | "mint" | "lavender" | "yellow";
+}
+
+interface Props {
+  chip?: Chip;
+  chips?: Chip[];
+  title: string;
+  subtitle?: string;
+  gradientTitle?: string;
+  centered?: boolean;
+}
+
+const { chip, chips, title, subtitle, gradientTitle, centered = true } = Astro.props;
+const variantClasses: Record<string, string> = {
+  coral: "pop-chip-coral",
+  mint: "pop-chip-mint",
+  lavender: "pop-chip-lavender",
+  yellow: "pop-chip-yellow",
+};
+---
+
+<section class:list={["px-8 py-20 relative z-10 md:px-5 md:py-12", { "text-center": centered }]}>
+  <div class:list={["mx-auto", centered ? "max-w-[700px]" : "max-w-[700px]"]}>
+    {
+      chips ? (
+        <div
+          class="flex justify-center gap-2 mb-8 flex-wrap opacity-0"
+          style="animation: popBounceIn 0.6s 0.1s forwards"
+        >
+          {chips.map((c) => (
+            <span class:list={["pop-chip", variantClasses[c.variant]]}>{c.label}</span>
+          ))}
+        </div>
+      ) : chip ? (
+        <span
+          class:list={["pop-chip", variantClasses[chip.variant]]}
+          style="animation: popBounceIn 0.6s 0.1s forwards"
+        >
+          {chip.label}
+        </span>
+      ) : null
+    }
+    <h1
+      class="font-display font-extrabold leading-[1.15] mb-6 tracking-tight opacity-0"
+      style="font-size: clamp(2rem, 5vw, 3rem); animation: popBounceIn 0.6s 0.25s forwards"
+    >
+      {title}
+      {
+        gradientTitle ? (
+          <>
+            <br />
+            <span class="bg-gradient-to-br from-[var(--sp-coral)] to-[var(--sp-lavender-dark)] bg-clip-text text-transparent">
+              {gradientTitle}
+            </span>
+          </>
+        ) : null
+      }
+    </h1>
+    {
+      subtitle ? (
+        <p
+          class:list={[
+            "text-[1.05rem] text-sp-text-muted leading-[1.7] m-0 opacity-0",
+            { "max-w-[520px] mx-auto": centered },
+          ]}
+          style="animation: popBounceIn 0.6s 0.4s forwards"
+        >
+          {subtitle}
+        </p>
+      ) : null
+    }
+  </div>
+</section>

--- a/src/components/marketing/layout/MarketingPageWrapper.astro
+++ b/src/components/marketing/layout/MarketingPageWrapper.astro
@@ -1,0 +1,10 @@
+---
+import FloatingShapes from "../../shared/FloatingShapes.astro";
+---
+
+<div class="relative overflow-x-hidden min-h-screen">
+  <FloatingShapes />
+  <div transition:animate="fade">
+    <slot />
+  </div>
+</div>

--- a/src/components/marketing/layout/PageContainer.astro
+++ b/src/components/marketing/layout/PageContainer.astro
@@ -1,0 +1,12 @@
+---
+interface Props {
+  class?: string;
+  children: unknown;
+}
+
+const { class: className } = Astro.props;
+---
+
+<div class:list={["max-w-[700px] mx-auto px-8 relative z-10 md:px-5", className]}>
+  <slot />
+</div>

--- a/src/components/marketing/sections/BentoCard.astro
+++ b/src/components/marketing/sections/BentoCard.astro
@@ -1,0 +1,37 @@
+---
+interface Props {
+  color: "coral" | "mint" | "lavender" | "yellow";
+  colSpan?: boolean;
+  delay?: number;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  icon: any;
+  title: string;
+  description: string;
+}
+
+const { color, colSpan = false, delay = 0, icon: Icon, title, description } = Astro.props;
+const colorBg: Record<string, string> = {
+  coral: "bg-sp-coral-light border-[rgba(255,107,107,0.15)]",
+  mint: "bg-sp-mint-light border-[rgba(45,212,191,0.15)]",
+  lavender: "bg-sp-lavender-light border-[rgba(167,139,250,0.15)]",
+  yellow: "bg-sp-yellow-light border-[rgba(253,230,138,0.3)]",
+};
+---
+
+<div
+  class:list={[
+    "bento-card group border border-transparent rounded-sp-xl p-8 transition-all duration-300 shadow-sp hover:translate-y-[-4px] hover:shadow-sp-hover",
+    colorBg[color],
+    { "md:col-span-2": colSpan },
+  ]}
+  data-reveal
+  data-reveal-delay={String(delay)}
+>
+  <div
+    class="bento-card-content opacity-0 translate-y-7 scale-[0.98] transition-[opacity,transform] duration-[550ms] [transition-timing-function:cubic-bezier(0.22,1,0.36,1)] group-[&.revealed]:opacity-100 group-[&.revealed]:translate-y-0 group-[&.revealed]:scale-100"
+  >
+    <Icon size={32} strokeWidth={1.75} class="block mb-4 opacity-80" />
+    <h3 class="font-display text-[1.2rem] font-bold mb-2 mt-0">{title}</h3>
+    <p class="text-[0.9rem] text-sp-text-muted leading-[1.6] m-0">{description}</p>
+  </div>
+</div>

--- a/src/components/marketing/sections/BentoGrid.astro
+++ b/src/components/marketing/sections/BentoGrid.astro
@@ -1,0 +1,12 @@
+---
+interface Props {
+  children: unknown;
+  class?: string;
+}
+
+const { class: className } = Astro.props;
+---
+
+<div class:list={["grid grid-cols-1 gap-4 md:grid-cols-2", className]}>
+  <slot />
+</div>

--- a/src/components/marketing/sections/CTACard.astro
+++ b/src/components/marketing/sections/CTACard.astro
@@ -1,0 +1,74 @@
+---
+import { ArrowRight } from "lucide-astro";
+import { makeHref } from "../../../lib/utils";
+import { ROUTES } from "../../../config/constants";
+
+interface Props {
+  title?: string;
+  subtitle?: string;
+  ctaLabel?: string;
+  ctaHref?: string;
+  size?: "default" | "lg";
+  background?: boolean;
+}
+
+const {
+  title = "Ready to give it a go?",
+  subtitle = "Free, open source, private, and offline-ready after the first visit.",
+  ctaLabel = "Open Reshrimp",
+  ctaHref = makeHref(ROUTES.APP),
+  size = "lg",
+  background = false,
+} = Astro.props;
+---
+
+<section class="px-8 py-20 text-center relative z-10">
+  <div class="max-w-[500px] mx-auto">
+    {
+      background ? (
+        <div class="bg-sp-bg-card border border-sp-border rounded-sp-xl p-12 text-center shadow-sp">
+          <h2
+            class="font-display font-extrabold mb-4 tracking-tight"
+            style="font-size: clamp(1.8rem, 4vw, 2.5rem)"
+            data-reveal
+            data-reveal-delay="0"
+          >
+            {title}
+          </h2>
+          <p
+            class="text-[1rem] text-sp-text-muted mb-8 leading-[1.6] m-0"
+            data-reveal
+            data-reveal-delay="80"
+          >
+            {subtitle}
+          </p>
+          <div data-reveal data-reveal-delay="160">
+            <a href={ctaHref} class:list={["cta-pop", { "cta-pop-lg": size === "lg" }]}>
+              {ctaLabel}
+              <ArrowRight size={18} strokeWidth={2} class="cta-pop-arrow" />
+            </a>
+          </div>
+        </div>
+      ) : (
+        <>
+          <h2
+            class="font-display font-extrabold mb-4 tracking-tight opacity-0"
+            style="font-size: clamp(1.8rem, 4vw, 2.5rem); animation: popBounceIn 0.6s 0.1s forwards"
+          >
+            {title}
+          </h2>
+          <p
+            class="text-[1rem] text-sp-text-muted mb-8 leading-[1.6] opacity-0"
+            style="animation: popBounceIn 0.6s 0.25s forwards"
+          >
+            {subtitle}
+          </p>
+          <a href={ctaHref} class:list={["cta-pop", { "cta-pop-lg": size === "lg" }]}>
+            {ctaLabel}
+            <ArrowRight size={18} strokeWidth={2} class="cta-pop-arrow" />
+          </a>
+        </>
+      )
+    }
+  </div>
+</section>

--- a/src/components/marketing/sections/ChangelogRelease.astro
+++ b/src/components/marketing/sections/ChangelogRelease.astro
@@ -1,0 +1,54 @@
+---
+interface Props {
+  version: string;
+  date: string;
+  sections: { title: string; items: string[] }[];
+  isLatest: boolean;
+}
+
+const { version, date, sections, isLatest } = Astro.props;
+
+function formatDate(dateStr: string) {
+  return new Date(`${dateStr}T00:00:00Z`).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}
+---
+
+<article
+  class="bg-sp-bg-card border border-sp-border rounded-sp-lg p-6 shadow-sp"
+  data-reveal
+  data-reveal-delay="0"
+>
+  <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+    <div>
+      <p class="font-display text-[1.25rem] font-bold tracking-tight text-sp-text">
+        v{version}
+      </p>
+      <time class="text-[0.85rem] text-sp-text-soft" datetime={`${date}T00:00:00Z`}>
+        {formatDate(date)}
+      </time>
+    </div>
+    {isLatest && <span class="pop-chip pop-chip-coral">Latest</span>}
+  </div>
+
+  <div class="mt-5 space-y-5">
+    {
+      sections.map((section) => (
+        <section>
+          <h2 class="text-[0.78rem] font-bold uppercase tracking-[0.08em] text-sp-text-muted mb-3">
+            {section.title}
+          </h2>
+          <ul class="space-y-2 pl-5">
+            {section.items.map((item) => (
+              <li class="text-[0.92rem] leading-[1.7] text-sp-text">{item}</li>
+            ))}
+          </ul>
+        </section>
+      ))
+    }
+  </div>
+</article>

--- a/src/components/marketing/sections/FAQAccordion.astro
+++ b/src/components/marketing/sections/FAQAccordion.astro
@@ -1,0 +1,47 @@
+---
+interface Props {
+  question: string;
+  answer: string;
+  delay?: number;
+}
+
+const { question, answer, delay = 0 } = Astro.props;
+---
+
+<div
+  class="faq-item group border border-sp-border rounded-sp bg-sp-bg-card mb-3 shadow-sp overflow-hidden transition-[border-color,box-shadow,transform] duration-[250ms] [transition-timing-function:cubic-bezier(0.34,1.56,0.64,1)]"
+  data-reveal
+  data-reveal-delay={String(delay)}
+>
+  <button
+    class="faq-question w-full text-left font-display text-[1.05rem] font-semibold py-5 px-6 flex items-center justify-between gap-4 transition-colors duration-200 hover:text-sp-coral"
+    aria-expanded="false"
+  >
+    {question}
+  </button>
+  <div
+    class="faq-body grid [grid-template-rows:0fr] transition-[grid-template-rows] duration-[400ms] [transition-timing-function:cubic-bezier(0.22,1,0.36,1)]"
+    role="region"
+  >
+    <div class="overflow-hidden">
+      <p
+        class="faq-answer text-[0.95rem] text-sp-text-muted leading-[1.7] px-6 pb-5 m-0 opacity-0 translate-y-[6px] transition-[opacity,transform] duration-300 delay-[80ms]"
+        set:html={answer}
+      />
+    </div>
+  </div>
+</div>
+
+<script>
+  const item = document.currentScript?.closest(".faq-item");
+  if (item) {
+    const question = item.querySelector(".faq-question");
+    if (question) {
+      const toggleItem = () => {
+        const isOpen = item.classList.toggle("faq-open");
+        question.setAttribute("aria-expanded", String(isOpen));
+      };
+      question.addEventListener("click", toggleItem);
+    }
+  }
+</script>

--- a/src/components/marketing/sections/FAQAccordion.astro
+++ b/src/components/marketing/sections/FAQAccordion.astro
@@ -33,15 +33,15 @@ const { question, answer, delay = 0 } = Astro.props;
 </div>
 
 <script>
-  const item = document.currentScript?.closest(".faq-item");
-  if (item) {
-    const question = item.querySelector(".faq-question");
-    if (question) {
-      const toggleItem = () => {
-        const isOpen = item.classList.toggle("faq-open");
-        question.setAttribute("aria-expanded", String(isOpen));
-      };
-      question.addEventListener("click", toggleItem);
-    }
+  // Use event delegation so all FAQ items work regardless of how many component instances exist
+  function handleFaqClick(e: Event) {
+    const question = (e.target as HTMLElement).closest(".faq-question");
+    if (!question) return;
+    const item = question.closest(".faq-item");
+    if (!item) return;
+    const isOpen = item.classList.toggle("faq-open");
+    question.setAttribute("aria-expanded", String(isOpen));
   }
+
+  document.addEventListener("click", handleFaqClick);
 </script>

--- a/src/components/marketing/sections/FeatureSection.astro
+++ b/src/components/marketing/sections/FeatureSection.astro
@@ -1,0 +1,46 @@
+---
+interface Props {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  icon: any;
+  title: string;
+  description: string;
+  color: "coral" | "mint" | "lavender" | "yellow";
+  index: number;
+}
+
+const { icon: Icon, title, description, color, index } = Astro.props;
+const colorBg: Record<string, string> = {
+  coral: "bg-sp-coral-light",
+  mint: "bg-sp-mint-light",
+  lavender: "bg-sp-lavender-light",
+  yellow: "bg-sp-yellow-light",
+};
+const colorStroke: Record<string, string> = {
+  coral: "text-sp-coral-dark",
+  mint: "text-sp-mint-dark",
+  lavender: "text-sp-lavender-dark",
+  yellow: "text-[#a16207]",
+};
+---
+
+<div
+  class:list={[
+    "flex items-center gap-10 max-sm:flex-col max-sm:text-center",
+    { "flex-row-reverse max-sm:flex-col": index % 2 === 1 },
+  ]}
+  data-reveal
+  data-reveal-delay={String(index * 80)}
+>
+  <div
+    class:list={[
+      "flex-shrink-0 w-[120px] h-[120px] rounded-sp-xl flex items-center justify-center shadow-sp max-sm:w-[100px] max-sm:h-[100px]",
+      colorBg[color],
+    ]}
+  >
+    <Icon size={40} strokeWidth={1.75} class={colorStroke[color]} />
+  </div>
+  <div class="flex-1">
+    <h2 class="font-display text-[1.35rem] font-bold mb-2 tracking-tight">{title}</h2>
+    <p class="text-[0.95rem] text-sp-text-muted leading-[1.7] m-0">{description}</p>
+  </div>
+</div>

--- a/src/components/marketing/sections/StepArrow.astro
+++ b/src/components/marketing/sections/StepArrow.astro
@@ -1,4 +1,6 @@
 ---
+import { ArrowRight } from "lucide-astro";
+
 interface Props {
   delay?: number;
 }
@@ -10,13 +12,5 @@ const { delay = 0 } = Astro.props;
   data-reveal
   data-reveal-delay={String(delay)}
 >
-  <svg width="40" height="24" viewBox="0 0 40 24" fill="none">
-    <path
-      d="M0 12h36M30 6l6 6-6 6"
-      stroke="currentColor"
-      stroke-width="2"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      opacity="0.3"></path>
-  </svg>
+  <ArrowRight size={24} strokeWidth={1.5} class="opacity-30" />
 </div>

--- a/src/components/marketing/sections/StepArrow.astro
+++ b/src/components/marketing/sections/StepArrow.astro
@@ -1,0 +1,22 @@
+---
+interface Props {
+  delay?: number;
+}
+const { delay = 0 } = Astro.props;
+---
+
+<div
+  class="text-sp-text-soft pt-4 shrink-0 md:rotate-90 md:pt-0"
+  data-reveal
+  data-reveal-delay={String(delay)}
+>
+  <svg width="40" height="24" viewBox="0 0 40 24" fill="none">
+    <path
+      d="M0 12h36M30 6l6 6-6 6"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      opacity="0.3"></path>
+  </svg>
+</div>

--- a/src/components/marketing/sections/StepItem.astro
+++ b/src/components/marketing/sections/StepItem.astro
@@ -1,0 +1,29 @@
+---
+interface Props {
+  number: number;
+  title: string;
+  description: string;
+  color: "coral" | "mint" | "lavender";
+  delay?: number;
+}
+
+const { number, title, description, color, delay = 0 } = Astro.props;
+const colorBg: Record<string, string> = {
+  coral: "bg-sp-coral text-white",
+  mint: "bg-sp-mint text-white",
+  lavender: "bg-sp-lavender text-white",
+};
+---
+
+<div class="flex-1 text-center max-w-[220px]" data-reveal data-reveal-delay={String(delay)}>
+  <div
+    class:list={[
+      "w-[52px] h-[52px] rounded-full flex items-center justify-center mx-auto mb-4",
+      colorBg[color],
+    ]}
+  >
+    <span class="font-display text-[1.2rem] font-bold">{number}</span>
+  </div>
+  <h3 class="font-display text-[1.05rem] font-bold mb-1">{title}</h3>
+  <p class="text-[0.85rem] text-sp-text-muted leading-[1.6] m-0">{description}</p>
+</div>

--- a/src/components/marketing/sections/StepSection.astro
+++ b/src/components/marketing/sections/StepSection.astro
@@ -1,0 +1,11 @@
+---
+
+---
+
+<section class="px-8 py-16 relative z-10">
+  <div class="max-w-[900px] mx-auto">
+    <div class="flex items-start justify-center gap-4 md:flex-col md:items-center">
+      <slot />
+    </div>
+  </div>
+</section>

--- a/src/components/marketing/sections/TrustBanner.astro
+++ b/src/components/marketing/sections/TrustBanner.astro
@@ -1,0 +1,46 @@
+---
+import { ShieldCheck } from "lucide-astro";
+---
+
+<section class="px-8 py-12 relative z-10">
+  <div class="max-w-[700px] mx-auto">
+    <div
+      class="bg-sp-bg-card border border-sp-border rounded-sp-xl p-12 text-center shadow-sp"
+      data-reveal
+    >
+      <div class="text-sp-mint mb-5">
+        <ShieldCheck size={36} strokeWidth={1.5} />
+      </div>
+      <h2 class="font-display text-[1.5rem] font-bold mb-4 tracking-tight">
+        Your images stay on your device. Period.
+      </h2>
+      <p class="text-[0.9rem] text-sp-text-muted leading-[1.7] max-w-[500px] mx-auto mb-6">
+        Reshrimp uses your browser's built-in APIs for all processing. After the first online visit,
+        the app shell and core tools work offline. Background removal also works offline after its
+        model assets are downloaded once. No uploads, accounts, or tracking.
+      </p>
+      <div class="flex justify-center flex-wrap gap-2">
+        <span
+          class="inline-block text-[0.7rem] font-semibold py-[0.3rem] px-[0.8rem] rounded-sp-full bg-sp-mint-light text-sp-mint-dark tracking-[0.01em]"
+          >No servers</span
+        >
+        <span
+          class="inline-block text-[0.7rem] font-semibold py-[0.3rem] px-[0.8rem] rounded-sp-full bg-sp-mint-light text-sp-mint-dark tracking-[0.01em]"
+          >No cookies</span
+        >
+        <span
+          class="inline-block text-[0.7rem] font-semibold py-[0.3rem] px-[0.8rem] rounded-sp-full bg-sp-mint-light text-sp-mint-dark tracking-[0.01em]"
+          >No analytics</span
+        >
+        <span
+          class="inline-block text-[0.7rem] font-semibold py-[0.3rem] px-[0.8rem] rounded-sp-full bg-sp-mint-light text-sp-mint-dark tracking-[0.01em]"
+          >No accounts</span
+        >
+        <span
+          class="inline-block text-[0.7rem] font-semibold py-[0.3rem] px-[0.8rem] rounded-sp-full bg-sp-mint-light text-sp-mint-dark tracking-[0.01em]"
+          >Open source</span
+        >
+      </div>
+    </div>
+  </div>
+</section>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,6 +1,7 @@
 ---
 import MarketingLayout from "../layouts/MarketingLayout.astro";
-import FloatingShapes from "../components/shared/FloatingShapes.astro";
+import MarketingPageWrapper from "../components/marketing/layout/MarketingPageWrapper.astro";
+import { ArrowRight } from "lucide-astro";
 import { makeHref } from "../lib/utils";
 import { ROUTES } from "../config/constants";
 ---
@@ -10,97 +11,28 @@ import { ROUTES } from "../config/constants";
   description="The page you're looking for doesn't exist. Resize, convert, and compress images right in your browser with Reshrimp."
   currentPath={ROUTES.HOME}
 >
-  <div class="page-pop">
-    <FloatingShapes />
-
-    <div class="not-found-main" transition:animate="fade">
-      <div class="not-found-container">
-        <div class="not-found-content">
-          <span class="not-found-code">404</span>
-          <h1 class="not-found-title">Page not found</h1>
-          <p class="not-found-message">
+  <MarketingPageWrapper>
+    <div class="flex items-center justify-center min-h-[calc(100vh-200px)] p-16 relative z-10">
+      <div class="max-w-[500px] text-center">
+        <div class="opacity-0" style="animation: popBounceIn 0.6s 0.1s forwards">
+          <span
+            class="inline-block font-display font-extrabold leading-none bg-gradient-to-br from-[var(--sp-coral)] to-[var(--sp-lavender)] bg-clip-text text-transparent"
+            style="font-size: clamp(5rem, 15vw, 8rem); letter-spacing: -0.03em;">404</span
+          >
+          <h1
+            class="font-display text-[clamp(1.8rem,4vw,2.5rem)] font-extrabold mt-4 mb-4 tracking-tight"
+          >
+            Page not found
+          </h1>
+          <p class="text-[1.1rem] text-sp-text-muted leading-[1.7] m-0 mb-10 max-w-[360px] mx-auto">
             Looks like this page drifted off into the void. Let's get you back on track.
           </p>
           <a href={makeHref(ROUTES.HOME)} class="cta-pop">
             Back to Home
-            <svg
-              width="18"
-              height="18"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              class="cta-pop-arrow"
-            >
-              <line x1="5" y1="12" x2="19" y2="12"></line>
-              <polyline points="12 5 19 12 12 19"></polyline>
-            </svg>
+            <ArrowRight size={18} strokeWidth={2} class="cta-pop-arrow" />
           </a>
         </div>
       </div>
     </div>
-  </div>
+  </MarketingPageWrapper>
 </MarketingLayout>
-
-<style>
-  .page-pop {
-    position: relative;
-    overflow-x: hidden;
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-  }
-
-  .not-found-main {
-    flex: 1;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 4rem 2rem;
-    position: relative;
-    z-index: 1;
-  }
-
-  .not-found-container {
-    max-width: 500px;
-    text-align: center;
-  }
-
-  .not-found-content {
-    opacity: 0;
-    animation: popBounceIn 0.6s 0.1s forwards;
-  }
-
-  .not-found-code {
-    display: inline-block;
-    font-family: var(--sp-font-display);
-    font-size: clamp(5rem, 15vw, 8rem);
-    font-weight: 800;
-    line-height: 1;
-    background: linear-gradient(135deg, var(--sp-coral), var(--sp-lavender));
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    letter-spacing: -0.03em;
-  }
-
-  .not-found-title {
-    font-family: var(--sp-font-display);
-    font-size: clamp(1.8rem, 4vw, 2.5rem);
-    font-weight: 800;
-    margin: 1rem 0 1rem;
-    letter-spacing: -0.02em;
-  }
-
-  .not-found-message {
-    font-size: 1.1rem;
-    color: var(--sp-text-muted);
-    line-height: 1.7;
-    margin: 0 0 2.5rem;
-    max-width: 360px;
-    margin-left: auto;
-    margin-right: auto;
-  }
-</style>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,11 +1,12 @@
 ---
 import MarketingLayout from "../layouts/MarketingLayout.astro";
 import MarketingPageWrapper from "../components/marketing/layout/MarketingPageWrapper.astro";
+import PageContainer from "../components/marketing/layout/PageContainer.astro";
 import HeroSection from "../components/marketing/hero/HeroSection.astro";
 import AboutCard from "../components/marketing/cards/AboutCard.astro";
 import TechStackGrid from "../components/marketing/cards/TechStackGrid.astro";
 import TechStackItem from "../components/marketing/cards/TechStackItem.astro";
-import { Github } from "lucide-astro";
+import { Github, ArrowRight } from "lucide-astro";
 import { makeHref } from "../lib/utils";
 import { GITHUB_URL, ROUTES } from "../config/constants";
 ---
@@ -23,7 +24,7 @@ import { GITHUB_URL, ROUTES } from "../config/constants";
     />
 
     <section class="px-8 py-8 pb-20 relative z-10">
-      <div class="max-w-[700px] mx-auto">
+      <PageContainer>
         <!-- The Mission -->
         <AboutCard delay={0}>
           <h2 class="font-display text-[1.25rem] font-bold mb-4 tracking-tight">
@@ -103,23 +104,11 @@ import { GITHUB_URL, ROUTES } from "../config/constants";
             </a>
             <a href={makeHref(ROUTES.APP)} class="cta-pop">
               Try Reshrimp
-              <svg
-                width="18"
-                height="18"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                class="cta-pop-arrow"
-                ><line x1="5" y1="12" x2="19" y2="12"></line><polyline points="12 5 19 12 12 19"
-                ></polyline></svg
-              >
+              <ArrowRight size={18} strokeWidth={2} class="cta-pop-arrow" />
             </a>
           </div>
         </AboutCard>
-      </div>
+      </PageContainer>
     </section>
   </MarketingPageWrapper>
 </MarketingLayout>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,6 +1,11 @@
 ---
 import MarketingLayout from "../layouts/MarketingLayout.astro";
-import FloatingShapes from "../components/shared/FloatingShapes.astro";
+import MarketingPageWrapper from "../components/marketing/layout/MarketingPageWrapper.astro";
+import HeroSection from "../components/marketing/hero/HeroSection.astro";
+import AboutCard from "../components/marketing/cards/AboutCard.astro";
+import TechStackGrid from "../components/marketing/cards/TechStackGrid.astro";
+import TechStackItem from "../components/marketing/cards/TechStackItem.astro";
+import { Github } from "lucide-astro";
 import { makeHref } from "../lib/utils";
 import { GITHUB_URL, ROUTES } from "../config/constants";
 ---
@@ -10,228 +15,111 @@ import { GITHUB_URL, ROUTES } from "../config/constants";
   description="Learn about the Reshrimp project — a free, open source, privacy-first image processing tool built for the browser."
   currentPath="/about"
 >
-  <div class="relative overflow-x-hidden min-h-screen">
-    <FloatingShapes />
+  <MarketingPageWrapper>
+    <HeroSection
+      chip={{ label: "About", variant: "coral" }}
+      title="Built for privacy. Built to prove something bigger."
+      subtitle="Reshrimp is a free, open source image processing tool that runs entirely in your browser. No uploads. No tracking. Just your images, processed locally."
+    />
 
-    <div transition:animate="fade">
-      <section class="px-8 py-20 text-center relative z-10 md:px-5 md:py-12">
-        <div class="max-w-[700px] mx-auto">
-          <span class="pop-chip pop-chip-coral">About</span>
-          <h1
-            class="font-display font-extrabold leading-[1.15] my-4 tracking-tight opacity-0"
-            style="font-size: clamp(2rem, 5vw, 3rem); animation: popBounceIn 0.6s 0.1s forwards"
-          >
-            Built for privacy. Built to prove something bigger.
-          </h1>
-          <p
-            class="text-[1.05rem] text-sp-text-muted leading-[1.7] m-0 opacity-0"
-            style="animation: popBounceIn 0.6s 0.25s forwards"
-          >
-            Reshrimp is a free, open source image processing tool that runs entirely in your
-            browser. No uploads. No tracking. Just your images, processed locally.
+    <section class="px-8 py-8 pb-20 relative z-10">
+      <div class="max-w-[700px] mx-auto">
+        <!-- The Mission -->
+        <AboutCard delay={0}>
+          <h2 class="font-display text-[1.25rem] font-bold mb-4 tracking-tight">
+            Why I built this
+          </h2>
+          <p class="text-[0.95rem] text-sp-text-muted leading-[1.7] mb-4 last:mb-0">
+            Most online image tools require uploading your photos to someone else's server. That
+            means trusting a third party with your personal images, waiting for uploads and
+            downloads, and dealing with file size limits and account requirements.
           </p>
-        </div>
-      </section>
+          <p class="text-[0.95rem] text-sp-text-muted leading-[1.7] mb-4 last:mb-0">
+            I built Reshrimp to prove that you don't need any of that. Modern browsers have
+            everything needed to resize, convert, and compress images — Canvas API, Blob handling,
+            and efficient JavaScript engines. Why send data across the internet when your computer
+            can handle it locally in milliseconds?
+          </p>
+          <p class="text-[0.95rem] text-sp-text-muted leading-[1.7] mb-4 last:mb-0">
+            But Reshrimp is more than a privacy tool — it's also my portfolio project. I wanted to
+            build something genuinely useful that demonstrates my ability to ship real products with
+            modern web technologies. From AI-powered background removal to smooth animations, this
+            project showcases what I can do.
+          </p>
+        </AboutCard>
 
-      <section class="px-8 py-8 pb-20 relative z-10">
-        <div class="max-w-[700px] mx-auto">
-          <!-- The Mission -->
-          <div
-            class="bg-sp-bg-card border border-sp-border rounded-sp-xl p-8 shadow-sp mb-6 about-card"
-            data-reveal
-            data-reveal-delay="0"
-          >
-            <h2 class="font-display text-[1.25rem] font-bold mb-4 tracking-tight about-card-title">
-              Why I built this
-            </h2>
-            <p class="text-[0.95rem] text-sp-text-muted leading-[1.7] mb-4 last:mb-0 about-card-p">
-              Most online image tools require uploading your photos to someone else's server. That
-              means trusting a third party with your personal images, waiting for uploads and
-              downloads, and dealing with file size limits and account requirements.
-            </p>
-            <p class="text-[0.95rem] text-sp-text-muted leading-[1.7] mb-4 last:mb-0 about-card-p">
-              I built Reshrimp to prove that you don't need any of that. Modern browsers have
-              everything needed to resize, convert, and compress images — Canvas API, Blob handling,
-              and efficient JavaScript engines. Why send data across the internet when your computer
-              can handle it locally in milliseconds?
-            </p>
-            <p class="text-[0.95rem] text-sp-text-muted leading-[1.7] mb-4 last:mb-0 about-card-p">
-              But Reshrimp is more than a privacy tool — it's also my portfolio project. I wanted to
-              build something genuinely useful that demonstrates my ability to ship real products
-              with modern web technologies. From AI-powered background removal to smooth animations,
-              this project showcases what I can do.
-            </p>
-          </div>
+        <!-- Tech Stack -->
+        <AboutCard delay={100}>
+          <h2 class="font-display text-[1.25rem] font-bold mb-4 tracking-tight">The tech stack</h2>
+          <p class="text-[0.95rem] text-sp-text-muted leading-[1.7] mb-4 last:mb-0">
+            I chose this stack intentionally — it's modern, type-safe, and performant. Each
+            technology serves a specific purpose in building a privacy-first tool.
+          </p>
+          <TechStackGrid>
+            <TechStackItem name="Astro" description="Static site framework" />
+            <TechStackItem name="Solid.js" description="Reactive interactive layer" />
+            <TechStackItem name="TypeScript" description="Type-safe processing logic" />
+            <TechStackItem name="Tailwind CSS" description="Utility-first styling" />
+            <TechStackItem name="Vercel" description="Edge deployment platform" />
+            <TechStackItem name="Vitest" description="Unit testing framework" />
+          </TechStackGrid>
+        </AboutCard>
 
-          <!-- Tech Stack -->
-          <div
-            class="bg-sp-bg-card border border-sp-border rounded-sp-xl p-8 shadow-sp mb-6 about-card"
-            data-reveal
-            data-reveal-delay="100"
-          >
-            <h2 class="font-display text-[1.25rem] font-bold mb-4 tracking-tight about-card-title">
-              The tech stack
-            </h2>
-            <p class="text-[0.95rem] text-sp-text-muted leading-[1.7] mb-4 last:mb-0 about-card-p">
-              I chose this stack intentionally — it's modern, type-safe, and performant. Each
-              technology serves a specific purpose in building a privacy-first tool.
-            </p>
-            <div class="grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] gap-4">
-              <div
-                class="bg-sp-bg border border-sp-border-light rounded-sp p-4 flex flex-col gap-1"
-              >
-                <span class="font-display font-semibold text-[0.95rem] about-tech-name">Astro</span>
-                <span class="text-[0.8rem] text-sp-text-soft about-tech-desc"
-                  >Static site framework</span
-                >
-              </div>
-              <div
-                class="bg-sp-bg border border-sp-border-light rounded-sp p-4 flex flex-col gap-1"
-              >
-                <span class="font-display font-semibold text-[0.95rem] about-tech-name"
-                  >Solid.js</span
-                >
-                <span class="text-[0.8rem] text-sp-text-soft about-tech-desc"
-                  >Reactive interactive layer</span
-                >
-              </div>
-              <div
-                class="bg-sp-bg border border-sp-border-light rounded-sp p-4 flex flex-col gap-1"
-              >
-                <span class="font-display font-semibold text-[0.95rem] about-tech-name"
-                  >TypeScript</span
-                >
-                <span class="text-[0.8rem] text-sp-text-soft about-tech-desc"
-                  >Type-safe processing logic</span
-                >
-              </div>
-              <div
-                class="bg-sp-bg border border-sp-border-light rounded-sp p-4 flex flex-col gap-1"
-              >
-                <span class="font-display font-semibold text-[0.95rem] about-tech-name"
-                  >Tailwind CSS</span
-                >
-                <span class="text-[0.8rem] text-sp-text-soft about-tech-desc"
-                  >Utility-first styling</span
-                >
-              </div>
-              <div
-                class="bg-sp-bg border border-sp-border-light rounded-sp p-4 flex flex-col gap-1"
-              >
-                <span class="font-display font-semibold text-[0.95rem] about-tech-name">Vercel</span
-                >
-                <span class="text-[0.8rem] text-sp-text-soft about-tech-desc"
-                  >Edge deployment platform</span
-                >
-              </div>
-              <div
-                class="bg-sp-bg border border-sp-border-light rounded-sp p-4 flex flex-col gap-1"
-              >
-                <span class="font-display font-semibold text-[0.95rem] about-tech-name">Vitest</span
-                >
-                <span class="text-[0.8rem] text-sp-text-soft about-tech-desc"
-                  >Unit testing framework</span
-                >
-              </div>
-            </div>
-          </div>
+        <!-- Privacy-First Architecture -->
+        <AboutCard delay={200}>
+          <h2 class="font-display text-[1.25rem] font-bold mb-4 tracking-tight">
+            Privacy by default
+          </h2>
+          <p class="text-[0.95rem] text-sp-text-muted leading-[1.7] mb-4 last:mb-0">
+            I believe software should respect users by default, not as an afterthought. Every pixel
+            of your image stays in your browser — it's never uploaded to a server, never tracked,
+            and never logged. The Canvas API handles everything locally, from resizing to background
+            removal.
+          </p>
+          <p class="text-[0.95rem] text-sp-text-muted leading-[1.7] mb-4 last:mb-0">
+            Even AI background removal runs client-side using WebAssembly. Your images are processed
+            by your own device's CPU and GPU, not by someone else's servers. You can verify this
+            yourself — the code is open source under the MIT license.
+          </p>
+        </AboutCard>
 
-          <!-- Privacy-First Architecture -->
-          <div
-            class="bg-sp-bg-card border border-sp-border rounded-sp-xl p-8 shadow-sp mb-6 about-card"
-            data-reveal
-            data-reveal-delay="200"
-          >
-            <h2 class="font-display text-[1.25rem] font-bold mb-4 tracking-tight about-card-title">
-              Privacy by default
-            </h2>
-            <p class="text-[0.95rem] text-sp-text-muted leading-[1.7] mb-4 last:mb-0 about-card-p">
-              I believe software should respect users by default, not as an afterthought. Every
-              pixel of your image stays in your browser — it's never uploaded to a server, never
-              tracked, and never logged. The Canvas API handles everything locally, from resizing to
-              background removal.
-            </p>
-            <p class="text-[0.95rem] text-sp-text-muted leading-[1.7] mb-4 last:mb-0 about-card-p">
-              Even AI background removal runs client-side using WebAssembly. Your images are
-              processed by your own device's CPU and GPU, not by someone else's servers. You can
-              verify this yourself — the code is open source under the MIT license.
-            </p>
-          </div>
-
-          <!-- Contributing -->
-          <div
-            class="bg-sp-bg-card border border-sp-border rounded-sp-xl p-8 shadow-sp mb-6 about-card"
-            data-reveal
-            data-reveal-delay="300"
-          >
-            <h2 class="font-display text-[1.25rem] font-bold mb-4 tracking-tight about-card-title">
-              Open source
-            </h2>
-            <p class="text-[0.95rem] text-sp-text-muted leading-[1.7] mb-4 last:mb-0 about-card-p">
-              Reshrimp is fully open source. You can read every line of code, fork it to self-host
-              it, or contribute improvements. I welcome pull requests for bug fixes, new features,
-              or documentation updates.
-            </p>
-            <div class="flex items-center gap-3 mt-5 flex-wrap about-cta-buttons">
-              <a
-                href={GITHUB_URL}
-                target="_blank"
-                rel="noopener noreferrer"
-                class="about-github-btn inline-flex items-center gap-2 font-body text-[0.9rem] font-semibold py-3 px-6 bg-sp-bg text-sp-text no-underline rounded-sp-full border border-sp-border transition-all duration-300 shadow-sp hover:translate-y-[-2px] hover:scale-102 hover:shadow-sp-hover hover:border-sp-lavender"
+        <!-- Contributing -->
+        <AboutCard delay={300}>
+          <h2 class="font-display text-[1.25rem] font-bold mb-4 tracking-tight">Open source</h2>
+          <p class="text-[0.95rem] text-sp-text-muted leading-[1.7] mb-4 last:mb-0">
+            Reshrimp is fully open source. You can read every line of code, fork it to self-host it,
+            or contribute improvements. I welcome pull requests for bug fixes, new features, or
+            documentation updates.
+          </p>
+          <div class="flex items-center gap-3 mt-5 flex-wrap">
+            <a
+              href={GITHUB_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="inline-flex items-center gap-2 font-body text-[0.9rem] font-semibold py-3 px-6 bg-sp-bg text-sp-text no-underline rounded-sp-full border border-sp-border transition-all duration-300 shadow-sp hover:translate-y-[-2px] hover:shadow-sp-hover hover:border-sp-lavender"
+            >
+              <Github size={18} />
+              View on GitHub
+            </a>
+            <a href={makeHref(ROUTES.APP)} class="cta-pop">
+              Try Reshrimp
+              <svg
+                width="18"
+                height="18"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                class="cta-pop-arrow"
+                ><line x1="5" y1="12" x2="19" y2="12"></line><polyline points="12 5 19 12 12 19"
+                ></polyline></svg
               >
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"
-                  ><path
-                    d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"
-                  ></path></svg
-                >
-                View on GitHub
-              </a>
-              <a href={makeHref(ROUTES.APP)} class="cta-pop">
-                Try Reshrimp
-                <svg
-                  width="18"
-                  height="18"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  class="cta-pop-arrow"
-                  ><line x1="5" y1="12" x2="19" y2="12"></line><polyline points="12 5 19 12 12 19"
-                  ></polyline></svg
-                >
-              </a>
-            </div>
+            </a>
           </div>
-        </div>
-      </section>
-    </div>
-  </div>
+        </AboutCard>
+      </div>
+    </section>
+  </MarketingPageWrapper>
 </MarketingLayout>
-
-<style>
-  /* Reveal animations */
-  [data-reveal] {
-    opacity: 0;
-    transform: translateY(28px) scale(0.98);
-    transition:
-      opacity 0.55s cubic-bezier(0.22, 1, 0.36, 1),
-      transform 0.55s cubic-bezier(0.22, 1, 0.36, 1);
-  }
-
-  [data-reveal].revealed {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
-
-  /* Custom hover scale class */
-  .hover\:scale-102:hover {
-    transform: translateY(-2px) scale(1.02);
-  }
-
-  /* Last child margin utility */
-  .about-card-p:last-child {
-    margin-bottom: 0;
-  }
-</style>

--- a/src/pages/changelog/index.astro
+++ b/src/pages/changelog/index.astro
@@ -1,7 +1,9 @@
 ---
 import changelogSource from "../../../CHANGELOG.md?raw";
 import MarketingLayout from "../../layouts/MarketingLayout.astro";
-import FloatingShapes from "../../components/shared/FloatingShapes.astro";
+import MarketingPageWrapper from "../../components/marketing/layout/MarketingPageWrapper.astro";
+import HeroSection from "../../components/marketing/hero/HeroSection.astro";
+import ChangelogRelease from "../../components/marketing/sections/ChangelogRelease.astro";
 
 type ReleaseSection = { title: string; items: string[] };
 type Release = { version: string; date: string; sections: ReleaseSection[] };
@@ -46,15 +48,6 @@ function parseChangelog(source: string): Release[] {
 }
 
 const releases = parseChangelog(changelogSource);
-
-function formatDate(date: string) {
-  return new Date(`${date}T00:00:00Z`).toLocaleDateString("en-US", {
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-    timeZone: "UTC",
-  });
-}
 ---
 
 <MarketingLayout
@@ -62,71 +55,26 @@ function formatDate(date: string) {
   description="A full history of updates, improvements, and new features in Reshrimp."
   currentPath="/changelog"
 >
-  <div class="relative overflow-x-hidden min-h-screen">
-    <FloatingShapes />
+  <MarketingPageWrapper>
+    <HeroSection
+      chip={{ label: "Changelog", variant: "mint" }}
+      title="What's new in Reshrimp"
+      subtitle="Every update, improvement, and fix — derived from the canonical changelog."
+    />
 
-    <div transition:animate="fade">
-      <section class="px-8 py-20 text-center relative z-10 md:px-5 md:py-12">
-        <div class="max-w-[900px] mx-auto">
-          <span class="pop-chip pop-chip-mint">Changelog</span>
-          <h1
-            class="font-display font-extrabold leading-[1.15] my-4 tracking-tight opacity-0"
-            style="font-size: clamp(2rem, 5vw, 3rem); animation: popBounceIn 0.6s 0.1s forwards"
-          >
-            What's new in Reshrimp
-          </h1>
-          <p
-            class="text-[1.05rem] text-sp-text-muted leading-[1.7] m-0 opacity-0"
-            style="animation: popBounceIn 0.6s 0.25s forwards"
-          >
-            Every update, improvement, and fix — derived from the canonical changelog.
-          </p>
-        </div>
-      </section>
-
-      <section class="px-8 py-8 pb-24 relative z-10">
-        <div class="max-w-[900px] mx-auto flex flex-col gap-10">
-          {
-            releases.map((release, i) => (
-              <article
-                class="bg-sp-bg-card border border-sp-border rounded-sp-lg p-6 shadow-sp"
-                data-reveal
-                data-reveal-delay={i * 80}
-              >
-                <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                  <div>
-                    <p class="font-display text-[1.25rem] font-bold tracking-tight text-sp-text">
-                      v{release.version}
-                    </p>
-                    <time
-                      class="text-[0.85rem] text-sp-text-soft"
-                      datetime={`${release.date}T00:00:00Z`}
-                    >
-                      {formatDate(release.date)}
-                    </time>
-                  </div>
-                  {i === 0 && <span class="pop-chip pop-chip-coral">Latest</span>}
-                </div>
-
-                <div class="mt-5 space-y-5">
-                  {release.sections.map((section) => (
-                    <section>
-                      <h2 class="text-[0.78rem] font-bold uppercase tracking-[0.08em] text-sp-text-muted mb-3">
-                        {section.title}
-                      </h2>
-                      <ul class="space-y-2 pl-5">
-                        {section.items.map((item) => (
-                          <li class="text-[0.92rem] leading-[1.7] text-sp-text">{item}</li>
-                        ))}
-                      </ul>
-                    </section>
-                  ))}
-                </div>
-              </article>
-            ))
-          }
-        </div>
-      </section>
-    </div>
-  </div>
+    <section class="px-8 py-8 pb-24 relative z-10">
+      <div class="max-w-[900px] mx-auto flex flex-col gap-10">
+        {
+          releases.map((release, i) => (
+            <ChangelogRelease
+              version={release.version}
+              date={release.date}
+              sections={release.sections}
+              isLatest={i === 0}
+            />
+          ))
+        }
+      </div>
+    </section>
+  </MarketingPageWrapper>
 </MarketingLayout>

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -1,6 +1,9 @@
 ---
 import MarketingLayout from "../layouts/MarketingLayout.astro";
-import FloatingShapes from "../components/shared/FloatingShapes.astro";
+import MarketingPageWrapper from "../components/marketing/layout/MarketingPageWrapper.astro";
+import HeroSection from "../components/marketing/hero/HeroSection.astro";
+import FAQAccordion from "../components/marketing/sections/FAQAccordion.astro";
+import { ArrowRight, Github } from "lucide-astro";
 import { makeHref } from "../lib/utils";
 import { GITHUB_URL, ROUTES } from "../config/constants";
 
@@ -52,189 +55,56 @@ const faqs = [
   description="Frequently asked questions about Reshrimp — a free, private, browser-based image processing tool."
   currentPath="/faq"
 >
-  <div class="relative overflow-x-hidden min-h-screen">
-    <FloatingShapes />
+  <MarketingPageWrapper>
+    <HeroSection
+      chip={{ label: "FAQ", variant: "yellow" }}
+      title="Frequently asked questions"
+      subtitle="Quick answers about privacy, formats, and offline use."
+    />
 
-    <div transition:animate="fade">
-      <section class="px-8 py-20 text-center relative z-10 md:px-5 md:py-12">
-        <div class="max-w-[700px] mx-auto">
-          <span class="pop-chip pop-chip-yellow">FAQ</span>
-          <h1
-            class="font-display font-extrabold leading-[1.15] my-4 tracking-tight opacity-0"
-            style="font-size: clamp(2rem, 5vw, 3rem); animation: popBounceIn 0.6s 0.1s forwards"
-          >
-            Frequently asked questions
-          </h1>
-          <p
-            class="text-[1.05rem] text-sp-text-muted leading-[1.7] m-0 opacity-0"
-            style="animation: popBounceIn 0.6s 0.25s forwards"
-          >
-            Quick answers about privacy, formats, and offline use.
-          </p>
-        </div>
-      </section>
+    <section class="px-8 py-8 pb-12 relative z-10">
+      <div class="max-w-[700px] mx-auto">
+        {
+          faqs.map((faq, i) => (
+            <FAQAccordion question={faq.question} answer={faq.answer} delay={i * 60} />
+          ))
+        }
+      </div>
+    </section>
 
-      <section class="px-8 py-8 pb-12 relative z-10">
-        <div class="max-w-[700px] mx-auto">
-          {
-            faqs.map((faq, i) => (
-              <div
-                class="faq-item group border border-sp-border rounded-sp bg-sp-bg-card mb-3 shadow-sp overflow-hidden transition-[border-color,box-shadow,transform] duration-[250ms] [transition-timing-function:cubic-bezier(0.34,1.56,0.64,1)]"
-                data-reveal
-                data-reveal-delay={i * 60}
-              >
-                <button
-                  class="faq-question w-full text-left font-display text-[1.05rem] font-semibold py-5 px-6 flex items-center justify-between gap-4 transition-colors duration-200 hover:text-sp-coral"
-                  aria-expanded="false"
-                >
-                  {faq.question}
-                </button>
-                <div
-                  class="faq-body grid [grid-template-rows:0fr] transition-[grid-template-rows] duration-[400ms] [transition-timing-function:cubic-bezier(0.22,1,0.36,1)]"
-                  role="region"
-                >
-                  <div class="overflow-hidden">
-                    <p
-                      class="faq-answer text-[0.95rem] text-sp-text-muted leading-[1.7] px-6 pb-5 m-0 opacity-0 translate-y-[6px] transition-[opacity,transform] duration-300 delay-[80ms]"
-                      set:html={faq.answer}
-                    />
-                  </div>
-                </div>
-              </div>
-            ))
-          }
-        </div>
-      </section>
-
-      <!-- CTA -->
-      <section class="px-8 py-8 pb-20 text-center relative z-10">
-        <div class="max-w-[500px] mx-auto">
-          <h2 class="font-display text-[1.5rem] font-bold mb-3" data-reveal data-reveal-delay="0">
-            Still have questions?
-          </h2>
-          <p
-            class="text-[1rem] text-sp-text-muted leading-[1.6] m-0"
-            data-reveal
-            data-reveal-delay="80"
+    <!-- CTA -->
+    <section class="px-8 py-8 pb-20 text-center relative z-10">
+      <div class="max-w-[500px] mx-auto">
+        <h2 class="font-display text-[1.5rem] font-bold mb-3" data-reveal data-reveal-delay="0">
+          Still have questions?
+        </h2>
+        <p
+          class="text-[1rem] text-sp-text-muted leading-[1.6] m-0"
+          data-reveal
+          data-reveal-delay="80"
+        >
+          Check out the source code or just try the app — it's the best way to see how it works.
+        </p>
+        <div
+          class="flex items-center justify-center gap-3 mt-6 flex-wrap"
+          data-reveal
+          data-reveal-delay="160"
+        >
+          <a href={makeHref(ROUTES.APP)} class="cta-pop">
+            Try Reshrimp
+            <ArrowRight size={18} strokeWidth={2} class="cta-pop-arrow" />
+          </a>
+          <a
+            href={GITHUB_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="inline-flex items-center gap-2 font-body text-[1rem] font-semibold py-[0.9rem] px-8 bg-sp-bg-card text-sp-text no-underline rounded-sp-full border border-sp-border transition-all duration-300 shadow-sp hover:translate-y-[-2px] hover:shadow-sp-hover hover:border-sp-lavender"
           >
-            Check out the source code or just try the app — it's the best way to see how it works.
-          </p>
-          <div
-            class="flex items-center justify-center gap-3 mt-6 flex-wrap"
-            data-reveal
-            data-reveal-delay="160"
-          >
-            <a href={makeHref(ROUTES.APP)} class="cta-pop">
-              Try Reshrimp
-              <svg
-                width="18"
-                height="18"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                class="cta-pop-arrow"
-                ><line x1="5" y1="12" x2="19" y2="12"></line><polyline points="12 5 19 12 12 19"
-                ></polyline></svg
-              >
-            </a>
-            <a
-              href={GITHUB_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-              class="faq-github-btn inline-flex items-center gap-2 font-body text-[1rem] font-semibold py-[0.9rem] px-8 bg-sp-bg-card text-sp-text no-underline rounded-sp-full border border-sp-border transition-all duration-300 shadow-sp hover:translate-y-[-2px] hover:scale-102 hover:shadow-sp-hover hover:border-sp-lavender"
-            >
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"
-                ><path
-                  d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"
-                ></path></svg
-              >
-              GitHub
-            </a>
-          </div>
+            <Github size={18} />
+            GitHub
+          </a>
         </div>
-      </section>
-    </div>
-  </div>
+      </div>
+    </section>
+  </MarketingPageWrapper>
 </MarketingLayout>
-
-<style>
-  /* ::after pseudo-element for the +/× icon */
-  .faq-question::after {
-    content: "+";
-    font-size: 1.3rem;
-    font-weight: 400;
-    color: var(--sp-coral);
-    flex-shrink: 0;
-    transition: transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
-  }
-
-  .faq-item.faq-open .faq-question::after {
-    transform: rotate(45deg);
-  }
-
-  /* Open state: grid row expansion */
-  .faq-item.faq-open .faq-body {
-    grid-template-rows: 1fr;
-  }
-
-  /* Open state: answer fade in */
-  .faq-item.faq-open .faq-answer {
-    opacity: 1;
-    transform: translateY(0);
-  }
-
-  /* Open state: card lift with lavender border */
-  .faq-item.faq-open {
-    border-color: var(--sp-lavender);
-    box-shadow: 0 4px 24px rgba(167, 139, 250, 0.14);
-    transform: scale(1.008);
-  }
-
-  /* :global() scoped link styles inside set:html answer content */
-  .faq-answer :global(a) {
-    color: var(--sp-coral);
-    text-decoration: underline;
-    text-decoration-color: rgba(255, 107, 107, 0.3);
-    text-underline-offset: 2px;
-    transition: text-decoration-color 0.2s;
-  }
-
-  .faq-answer :global(a:hover) {
-    text-decoration-color: var(--sp-coral);
-  }
-
-  /* Custom hover scale class */
-  .hover\:scale-102:hover {
-    transform: translateY(-2px) scale(1.02);
-  }
-</style>
-
-<script>
-  import { registerPageInitializer } from "../lib/pageInitializer";
-
-  function initFaq() {
-    const cleanups: Array<() => void> = [];
-
-    document.querySelectorAll(".faq-item").forEach((item) => {
-      const question = item.querySelector(".faq-question");
-      if (!question) return;
-
-      const toggleItem = () => {
-        const isOpen = item.classList.toggle("faq-open");
-        question.setAttribute("aria-expanded", String(isOpen));
-      };
-
-      question.addEventListener("click", toggleItem);
-      cleanups.push(() => question.removeEventListener("click", toggleItem));
-    });
-
-    return () => {
-      cleanups.forEach((cleanup) => cleanup());
-    };
-  }
-
-  registerPageInitializer("faq:accordion", () => initFaq());
-</script>

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -1,6 +1,7 @@
 ---
 import MarketingLayout from "../layouts/MarketingLayout.astro";
 import MarketingPageWrapper from "../components/marketing/layout/MarketingPageWrapper.astro";
+import PageContainer from "../components/marketing/layout/PageContainer.astro";
 import HeroSection from "../components/marketing/hero/HeroSection.astro";
 import FAQAccordion from "../components/marketing/sections/FAQAccordion.astro";
 import { ArrowRight, Github } from "lucide-astro";
@@ -63,13 +64,13 @@ const faqs = [
     />
 
     <section class="px-8 py-8 pb-12 relative z-10">
-      <div class="max-w-[700px] mx-auto">
+      <PageContainer>
         {
           faqs.map((faq, i) => (
             <FAQAccordion question={faq.question} answer={faq.answer} delay={i * 60} />
           ))
         }
-      </div>
+      </PageContainer>
     </section>
 
     <!-- CTA -->

--- a/src/pages/features.astro
+++ b/src/pages/features.astro
@@ -1,8 +1,9 @@
 ---
 import MarketingLayout from "../layouts/MarketingLayout.astro";
-import FloatingShapes from "../components/shared/FloatingShapes.astro";
-import { makeHref } from "../lib/utils";
-import { ROUTES } from "../config/constants";
+import MarketingPageWrapper from "../components/marketing/layout/MarketingPageWrapper.astro";
+import HeroSection from "../components/marketing/hero/HeroSection.astro";
+import FeatureSection from "../components/marketing/sections/FeatureSection.astro";
+import CTACard from "../components/marketing/sections/CTACard.astro";
 import { Scaling, ArrowLeftRight, Gauge, ShieldCheck, WifiOff, Code, Wand2 } from "lucide-astro";
 
 const features = [
@@ -63,153 +64,37 @@ const features = [
   description="Resize, convert, compress, and process images privately in your browser. Explore all features of Reshrimp."
   currentPath="/features"
 >
-  <div class="relative overflow-x-hidden min-h-screen">
-    <FloatingShapes />
+  <MarketingPageWrapper>
     <!-- Hero -->
-    <section class="px-8 py-20 text-center relative z-10 md:px-5 md:py-12">
-      <div class="max-w-[650px] mx-auto">
-        <span class="pop-chip pop-chip-lavender">Features</span>
-        <h1
-          class="font-display font-extrabold leading-[1.15] my-4 tracking-tight opacity-0"
-          style="font-size: clamp(2rem, 5vw, 3rem); animation: popBounceIn 0.6s 0.1s forwards"
-        >
-          Everything you need.<br />
-          <span
-            class="bg-gradient-to-br from-[var(--sp-coral)] to-[var(--sp-lavender-dark)] bg-clip-text text-transparent"
-          >
-            Nothing you don't.
-          </span>
-        </h1>
-        <p
-          class="text-[1.05rem] text-sp-text-muted leading-[1.7] m-0 opacity-0"
-          style="animation: popBounceIn 0.6s 0.25s forwards"
-        >
-          Reshrimp packs private image processing into a clean browser-based tool. After the first
-          online visit, the app shell and core tools work offline.
-        </p>
-      </div>
-    </section>
+    <HeroSection
+      chip={{ label: "Features", variant: "lavender" }}
+      title="Everything you need."
+      gradientTitle="Nothing you don't."
+      subtitle="Reshrimp packs private image processing into a clean browser-based tool. After the first online visit, the app shell and core tools work offline."
+    />
 
     <!-- Feature sections -->
     <section class="px-8 py-8 pb-16 relative z-10">
       <div class="max-w-[900px] mx-auto flex flex-col gap-12">
         {
           features.map((feature, i) => (
-            <div
-              class:list={["flex items-center gap-10", { "flex-row-reverse": i % 2 === 1 }]}
-              data-reveal
-              data-reveal-delay={i * 80}
-            >
-              <div
-                class={`flex-shrink-0 w-[120px] h-[120px] rounded-sp-xl flex items-center justify-center shadow-sp feature-icon-box feature-icon-${feature.color}`}
-              >
-                <feature.icon
-                  size={40}
-                  strokeWidth={1.75}
-                  class={`feature-icon feature-icon-stroke-${feature.color}`}
-                />
-              </div>
-              <div class="flex-1 feature-text">
-                <h2 class="font-display text-[1.35rem] font-bold mb-2 tracking-tight feature-title">
-                  {feature.title}
-                </h2>
-                <p class="text-[0.95rem] text-sp-text-muted leading-[1.7] m-0 feature-desc">
-                  {feature.description}
-                </p>
-              </div>
-            </div>
+            <FeatureSection
+              icon={feature.icon}
+              title={feature.title}
+              description={feature.description}
+              color={feature.color}
+              index={i}
+            />
           ))
         }
       </div>
     </section>
 
     <!-- CTA -->
-    <section class="px-8 py-16 pb-20 text-center relative z-10">
-      <div class="max-w-[500px] mx-auto">
-        <div class="bg-sp-bg-card border border-sp-border rounded-sp-xl p-12 text-center shadow-sp">
-          <h2
-            class="font-display font-extrabold mb-4 tracking-tight"
-            style="font-size: clamp(1.8rem, 4vw, 2.5rem)"
-            data-reveal
-            data-reveal-delay="0"
-          >
-            Ready to try it?
-          </h2>
-          <p
-            class="text-[1rem] text-sp-text-muted mb-8 leading-[1.6] m-0"
-            data-reveal
-            data-reveal-delay="80"
-          >
-            Free, open source, private, and offline-ready after the first visit.
-          </p>
-          <div data-reveal data-reveal-delay="160">
-            <a href={makeHref(ROUTES.APP)} class="cta-pop cta-pop-lg">
-              Open Reshrimp
-              <svg
-                width="18"
-                height="18"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                class="cta-pop-arrow"
-              >
-                <line x1="5" y1="12" x2="19" y2="12"></line>
-                <polyline points="12 5 19 12 12 19"></polyline>
-              </svg>
-            </a>
-          </div>
-        </div>
-      </div>
-    </section>
-  </div>
+    <CTACard
+      title="Ready to try it?"
+      subtitle="Free, open source, private, and offline-ready after the first visit."
+      background={true}
+    />
+  </MarketingPageWrapper>
 </MarketingLayout>
-
-<style>
-  .feature-icon-coral {
-    background: var(--sp-coral-light);
-  }
-
-  .feature-icon-mint {
-    background: var(--sp-mint-light);
-  }
-
-  .feature-icon-lavender {
-    background: var(--sp-lavender-light);
-  }
-
-  .feature-icon-yellow {
-    background: var(--sp-yellow-light);
-  }
-
-  .feature-icon-stroke-coral {
-    color: var(--sp-coral-dark);
-  }
-
-  .feature-icon-stroke-mint {
-    color: var(--sp-mint-dark);
-  }
-
-  .feature-icon-stroke-lavender {
-    color: var(--sp-lavender-dark);
-  }
-
-  .feature-icon-stroke-yellow {
-    color: #a16207;
-  }
-
-  @media (max-width: 640px) {
-    .feature-row,
-    .feature-row-reverse {
-      flex-direction: column;
-      text-align: center;
-    }
-
-    .feature-icon-box {
-      width: 100px;
-      height: 100px;
-    }
-  }
-</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,10 +1,18 @@
 ---
 import MarketingLayout from "../layouts/MarketingLayout.astro";
-import FloatingShapes from "../components/shared/FloatingShapes.astro";
 import SectionHeader from "../components/shared/SectionHeader.astro";
-import { makeHref } from "../lib/utils";
-import { ROUTES, SITE_NAME, SITE_DESCRIPTION } from "../config/constants";
+import MarketingPageWrapper from "../components/marketing/layout/MarketingPageWrapper.astro";
+import HeroSection from "../components/marketing/hero/HeroSection.astro";
+import HeroCTA from "../components/marketing/hero/HeroCTA.astro";
+import BentoGrid from "../components/marketing/sections/BentoGrid.astro";
+import BentoCard from "../components/marketing/sections/BentoCard.astro";
+import StepSection from "../components/marketing/sections/StepSection.astro";
+import StepItem from "../components/marketing/sections/StepItem.astro";
+import StepArrow from "../components/marketing/sections/StepArrow.astro";
+import TrustBanner from "../components/marketing/sections/TrustBanner.astro";
+import CTACard from "../components/marketing/sections/CTACard.astro";
 import { Scaling, ArrowLeftRight, Gauge, ShieldCheck } from "lucide-astro";
+import { SITE_NAME, SITE_DESCRIPTION } from "../config/constants";
 
 const siteUrl = new URL(Astro.url.pathname, Astro.site).href;
 const jsonLd = {
@@ -28,302 +36,91 @@ const jsonLd = {
   <Fragment slot="head">
     <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
   </Fragment>
-  <div class="relative overflow-x-hidden min-h-screen">
-    <FloatingShapes />
+  <MarketingPageWrapper>
+    <!-- Hero -->
+    <HeroSection
+      chips={[
+        { label: "Free forever", variant: "mint" },
+        { label: "100% private", variant: "coral" },
+        { label: "Offline-ready", variant: "lavender" },
+      ]}
+      title="Your images deserve"
+      gradientTitle="better than the cloud."
+      subtitle="Resize, convert, and compress images right in your browser. Nothing gets uploaded. Nothing gets tracked. After one online visit, the app shell and core tools work offline."
+    >
+      <HeroCTA secondaryText="No sign-up · Offline-ready" />
+    </HeroSection>
 
-    <div transition:animate="fade">
-      <!-- Hero -->
-      <section class="px-8 py-20 text-center relative z-10 md:px-5 md:py-16 md:px-6">
-        <div class="max-w-[700px] mx-auto">
-          <div
-            class="flex justify-center gap-2 mb-8 flex-wrap opacity-0"
-            style="animation: popBounceIn 0.6s 0.1s forwards"
-          >
-            <span class="pop-chip pop-chip-mint">Free forever</span>
-            <span class="pop-chip pop-chip-coral">100% private</span>
-            <span class="pop-chip pop-chip-lavender">Offline-ready</span>
-          </div>
-          <h1
-            class="font-display font-extrabold leading-[1.15] mb-6 tracking-tight opacity-0"
-            style="font-size: clamp(2.2rem, 5.5vw, 3.5rem); animation: popBounceIn 0.6s 0.25s forwards"
-          >
-            Your images deserve<br />
-            <span
-              class="bg-gradient-to-br from-[var(--sp-coral)] to-[var(--sp-lavender-dark)] bg-clip-text text-transparent"
-            >
-              better than the cloud.
-            </span>
-          </h1>
-          <p
-            class="text-[1.1rem] text-sp-text-muted leading-[1.7] max-w-[520px] mx-auto mb-8 opacity-0"
-            style="animation: popBounceIn 0.6s 0.4s forwards"
-          >
-            Resize, convert, and compress images right in your browser. Nothing gets uploaded.
-            Nothing gets tracked. After one online visit, the app shell and core tools work offline.
-          </p>
-          <div
-            class="flex flex-col items-center gap-3 opacity-0"
-            style="animation: popBounceIn 0.6s 0.55s forwards"
-          >
-            <a href={makeHref(ROUTES.APP)} class="cta-pop">
-              Start processing
-              <svg
-                width="18"
-                height="18"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                class="cta-pop-arrow"
-              >
-                <line x1="5" y1="12" x2="19" y2="12"></line>
-                <polyline points="12 5 19 12 12 19"></polyline>
-              </svg>
-            </a>
-            <span class="text-[0.8rem] text-sp-text-soft">No sign-up &middot; Offline-ready</span>
-          </div>
-        </div>
-      </section>
+    <!-- Bento Features -->
+    <section class="px-8 py-16 relative z-10">
+      <div class="max-w-[1000px] mx-auto">
+        <SectionHeader label="What can you do?" title="Everything you need. Nothing you don't." />
+        <BentoGrid>
+          <BentoCard
+            color="coral"
+            colSpan={true}
+            icon={Scaling}
+            title="Resize with precision"
+            description="Scale to exact pixel dimensions. Aspect ratio lock keeps everything balanced. Works for thumbnails, social media, or high-res exports."
+          />
+          <BentoCard
+            color="mint"
+            icon={ArrowLeftRight}
+            title="Convert formats"
+            description="Switch between JPEG, PNG, and WebP in a click. Browser-native conversion with format-specific quality tradeoffs."
+          />
+          <BentoCard
+            color="lavender"
+            icon={Gauge}
+            title="Compress smartly"
+            description="Fine-tune quality from 0-100%. Check original and processed results in a tabbed preview."
+          />
+          <BentoCard
+            color="yellow"
+            colSpan={true}
+            icon={ShieldCheck}
+            title="Completely private"
+            description="All processing happens locally via browser APIs. After the first online visit, the app shell and core tools work offline. Open source — verify it yourself."
+          />
+        </BentoGrid>
+      </div>
+    </section>
 
-      <!-- Bento Features -->
-      <section class="px-8 py-16 relative z-10">
-        <div class="max-w-[1000px] mx-auto">
-          <SectionHeader label="What can you do?" title="Everything you need. Nothing you don't." />
-          <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
-            <div
-              class="bento-card group border border-transparent rounded-sp-xl p-8 transition-all duration-300 shadow-sp hover:translate-y-[-4px] hover:shadow-sp-hover bg-sp-coral-light border-[rgba(255,107,107,0.15)] md:col-span-2"
-              data-reveal
-              data-reveal-delay="0"
-            >
-              <div
-                class="bento-card-content opacity-0 translate-y-7 scale-[0.98] transition-[opacity,transform] duration-[550ms] [transition-timing-function:cubic-bezier(0.22,1,0.36,1)] group-[&.revealed]:opacity-100 group-[&.revealed]:translate-y-0 group-[&.revealed]:scale-100"
-              >
-                <Scaling size={32} strokeWidth={1.75} class="block mb-4 opacity-80" />
-                <h3 class="font-display text-[1.2rem] font-bold mb-2 mt-0">
-                  Resize with precision
-                </h3>
-                <p class="text-[0.9rem] text-sp-text-muted leading-[1.6] m-0">
-                  Scale to exact pixel dimensions. Aspect ratio lock keeps everything balanced.
-                  Works for thumbnails, social media, or high-res exports.
-                </p>
-              </div>
-            </div>
-            <div
-              class="bento-card group border border-transparent rounded-sp-xl p-8 transition-all duration-300 shadow-sp hover:translate-y-[-4px] hover:shadow-sp-hover bg-sp-mint-light border-[rgba(45,212,191,0.15)]"
-              data-reveal
-              data-reveal-delay="80"
-            >
-              <div
-                class="bento-card-content opacity-0 translate-y-7 scale-[0.98] transition-[opacity,transform] duration-[550ms] [transition-timing-function:cubic-bezier(0.22,1,0.36,1)] group-[&.revealed]:opacity-100 group-[&.revealed]:translate-y-0 group-[&.revealed]:scale-100"
-              >
-                <ArrowLeftRight size={32} strokeWidth={1.75} class="block mb-4 opacity-80" />
-                <h3 class="font-display text-[1.2rem] font-bold mb-2 mt-0">Convert formats</h3>
-                <p class="text-[0.9rem] text-sp-text-muted leading-[1.6] m-0">
-                  Switch between JPEG, PNG, and WebP in a click. Browser-native conversion with
-                  format-specific quality tradeoffs.
-                </p>
-              </div>
-            </div>
-            <div
-              class="bento-card group border border-transparent rounded-sp-xl p-8 transition-all duration-300 shadow-sp hover:translate-y-[-4px] hover:shadow-sp-hover bg-sp-lavender-light border-[rgba(167,139,250,0.15)]"
-              data-reveal
-              data-reveal-delay="160"
-            >
-              <div
-                class="bento-card-content opacity-0 translate-y-7 scale-[0.98] transition-[opacity,transform] duration-[550ms] [transition-timing-function:cubic-bezier(0.22,1,0.36,1)] group-[&.revealed]:opacity-100 group-[&.revealed]:translate-y-0 group-[&.revealed]:scale-100"
-              >
-                <Gauge size={32} strokeWidth={1.75} class="block mb-4 opacity-80" />
-                <h3 class="font-display text-[1.2rem] font-bold mb-2 mt-0">Compress smartly</h3>
-                <p class="text-[0.9rem] text-sp-text-muted leading-[1.6] m-0">
-                  Fine-tune quality from 0-100%. Check original and processed results in a tabbed
-                  preview.
-                </p>
-              </div>
-            </div>
-            <div
-              class="bento-card group border border-transparent rounded-sp-xl p-8 transition-all duration-300 shadow-sp hover:translate-y-[-4px] hover:shadow-sp-hover bg-sp-yellow-light border-[rgba(253,230,138,0.3)] md:col-span-2"
-              data-reveal
-              data-reveal-delay="240"
-            >
-              <div
-                class="bento-card-content opacity-0 translate-y-7 scale-[0.98] transition-[opacity,transform] duration-[550ms] [transition-timing-function:cubic-bezier(0.22,1,0.36,1)] group-[&.revealed]:opacity-100 group-[&.revealed]:translate-y-0 group-[&.revealed]:scale-100"
-              >
-                <ShieldCheck size={32} strokeWidth={1.75} class="block mb-4 opacity-80" />
-                <h3 class="font-display text-[1.2rem] font-bold mb-2 mt-0">Completely private</h3>
-                <p class="text-[0.9rem] text-sp-text-muted leading-[1.6] m-0">
-                  All processing happens locally via browser APIs. After the first online visit, the
-                  app shell and core tools work offline. Open source — verify it yourself.
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
+    <!-- How it works -->
+    <section class="px-8 py-16 relative z-10">
+      <div class="max-w-[900px] mx-auto">
+        <SectionHeader label="Dead simple" title="Three steps. Seriously." />
+        <StepSection>
+          <StepItem
+            number={1}
+            color="coral"
+            title="Drop your image"
+            description="Drag and drop or click to browse. Supports JPEG, PNG, and WebP."
+          />
+          <StepArrow delay={100} />
+          <StepItem
+            number={2}
+            color="mint"
+            title="Tweak the settings"
+            description="Set dimensions, pick a format, adjust quality, then process to review the result."
+            delay={200}
+          />
+          <StepArrow delay={300} />
+          <StepItem
+            number={3}
+            color="lavender"
+            title="Download instantly"
+            description="One click to process, one click to download. Compare before and after."
+            delay={400}
+          />
+        </StepSection>
+      </div>
+    </section>
 
-      <!-- How it works -->
-      <section class="px-8 py-16 relative z-10">
-        <div class="max-w-[900px] mx-auto">
-          <SectionHeader label="Dead simple" title="Three steps. Seriously." />
-          <div class="flex items-start justify-center gap-4 md:flex-col md:items-center">
-            <div class="flex-1 text-center max-w-[220px]" data-reveal data-reveal-delay="0">
-              <div
-                class="w-[52px] h-[52px] rounded-full flex items-center justify-center mx-auto mb-4 bg-sp-coral text-white"
-              >
-                <span class="font-display text-[1.2rem] font-bold">1</span>
-              </div>
-              <h3 class="font-display text-[1.05rem] font-bold mb-1">Drop your image</h3>
-              <p class="text-[0.85rem] text-sp-text-muted leading-[1.6] m-0">
-                Drag and drop or click to browse. Supports JPEG, PNG, and WebP.
-              </p>
-            </div>
-            <div
-              class="text-sp-text-soft pt-4 shrink-0 md:rotate-90 md:pt-0"
-              data-reveal
-              data-reveal-delay="100"
-            >
-              <svg width="40" height="24" viewBox="0 0 40 24" fill="none">
-                <path
-                  d="M0 12h36M30 6l6 6-6 6"
-                  stroke="currentColor"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  opacity="0.3"></path>
-              </svg>
-            </div>
-            <div class="flex-1 text-center max-w-[220px]" data-reveal data-reveal-delay="200">
-              <div
-                class="w-[52px] h-[52px] rounded-full flex items-center justify-center mx-auto mb-4 bg-sp-mint text-white"
-              >
-                <span class="font-display text-[1.2rem] font-bold">2</span>
-              </div>
-              <h3 class="font-display text-[1.05rem] font-bold mb-1">Tweak the settings</h3>
-              <p class="text-[0.85rem] text-sp-text-muted leading-[1.6] m-0">
-                Set dimensions, pick a format, adjust quality, then process to review the result.
-              </p>
-            </div>
-            <div
-              class="text-sp-text-soft pt-4 shrink-0 md:rotate-90 md:pt-0"
-              data-reveal
-              data-reveal-delay="300"
-            >
-              <svg width="40" height="24" viewBox="0 0 40 24" fill="none">
-                <path
-                  d="M0 12h36M30 6l6 6-6 6"
-                  stroke="currentColor"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  opacity="0.3"></path>
-              </svg>
-            </div>
-            <div class="flex-1 text-center max-w-[220px]" data-reveal data-reveal-delay="400">
-              <div
-                class="w-[52px] h-[52px] rounded-full flex items-center justify-center mx-auto mb-4 bg-sp-lavender text-white"
-              >
-                <span class="font-display text-[1.2rem] font-bold">3</span>
-              </div>
-              <h3 class="font-display text-[1.05rem] font-bold mb-1">Download instantly</h3>
-              <p class="text-[0.85rem] text-sp-text-muted leading-[1.6] m-0">
-                One click to process, one click to download. Compare before and after.
-              </p>
-            </div>
-          </div>
-        </div>
-      </section>
+    <!-- Trust banner -->
+    <TrustBanner />
 
-      <!-- Trust banner -->
-      <section class="px-8 py-12 relative z-10">
-        <div class="max-w-[700px] mx-auto">
-          <div
-            class="bg-sp-bg-card border border-sp-border rounded-sp-xl p-12 text-center shadow-sp"
-            data-reveal
-          >
-            <div class="text-sp-mint mb-5">
-              <svg
-                width="36"
-                height="36"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="1.5"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              >
-                <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path>
-                <path d="M9 12l2 2 4-4"></path>
-              </svg>
-            </div>
-            <h2 class="font-display text-[1.5rem] font-bold mb-4 tracking-tight">
-              Your images stay on your device. Period.
-            </h2>
-            <p class="text-[0.9rem] text-sp-text-muted leading-[1.7] max-w-[500px] mx-auto mb-6">
-              Reshrimp uses your browser's built-in APIs for all processing. After the first online
-              visit, the app shell and core tools work offline. Background removal also works
-              offline after its model assets are downloaded once. No uploads, accounts, or tracking.
-            </p>
-            <div class="flex justify-center flex-wrap gap-2">
-              <span
-                class="inline-block text-[0.7rem] font-semibold py-[0.3rem] px-[0.8rem] rounded-sp-full bg-sp-mint-light text-sp-mint-dark tracking-[0.01em]"
-                >No servers</span
-              >
-              <span
-                class="inline-block text-[0.7rem] font-semibold py-[0.3rem] px-[0.8rem] rounded-sp-full bg-sp-mint-light text-sp-mint-dark tracking-[0.01em]"
-                >No cookies</span
-              >
-              <span
-                class="inline-block text-[0.7rem] font-semibold py-[0.3rem] px-[0.8rem] rounded-sp-full bg-sp-mint-light text-sp-mint-dark tracking-[0.01em]"
-                >No analytics</span
-              >
-              <span
-                class="inline-block text-[0.7rem] font-semibold py-[0.3rem] px-[0.8rem] rounded-sp-full bg-sp-mint-light text-sp-mint-dark tracking-[0.01em]"
-                >No accounts</span
-              >
-              <span
-                class="inline-block text-[0.7rem] font-semibold py-[0.3rem] px-[0.8rem] rounded-sp-full bg-sp-mint-light text-sp-mint-dark tracking-[0.01em]"
-                >Open source</span
-              >
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <!-- Final CTA -->
-      <section class="px-8 py-20 text-center relative z-10">
-        <div class="max-w-[500px] mx-auto">
-          <h2
-            class="font-display font-extrabold mb-4 tracking-tight opacity-0"
-            style="font-size: clamp(1.8rem, 4vw, 2.5rem); animation: popBounceIn 0.6s 0.1s forwards"
-          >
-            Ready to give it a go?
-          </h2>
-          <p
-            class="text-[1rem] text-sp-text-muted mb-8 leading-[1.6] opacity-0"
-            style="animation: popBounceIn 0.6s 0.25s forwards"
-          >
-            Free, open source, private, and offline-ready after the first visit.
-          </p>
-          <a href={makeHref(ROUTES.APP)} class="cta-pop cta-pop-lg">
-            Open Reshrimp
-            <svg
-              width="18"
-              height="18"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              class="cta-pop-arrow"
-            >
-              <line x1="5" y1="12" x2="19" y2="12"></line>
-              <polyline points="12 5 19 12 12 19"></polyline>
-            </svg>
-          </a>
-        </div>
-      </section>
-    </div>
-  </div>
+    <!-- Final CTA -->
+    <CTACard />
+  </MarketingPageWrapper>
 </MarketingLayout>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -1,6 +1,7 @@
 ---
 import MarketingLayout from "../layouts/MarketingLayout.astro";
 import MarketingPageWrapper from "../components/marketing/layout/MarketingPageWrapper.astro";
+import PageContainer from "../components/marketing/layout/PageContainer.astro";
 import HeroSection from "../components/marketing/hero/HeroSection.astro";
 import PrivacyCard from "../components/marketing/cards/PrivacyCard.astro";
 import { GITHUB_URL } from "../config/constants";
@@ -19,7 +20,7 @@ import { GITHUB_URL } from "../config/constants";
     />
 
     <section class="px-8 py-8 pb-20 relative z-10">
-      <div class="max-w-[700px] mx-auto">
+      <PageContainer>
         <!-- How it works -->
         <PrivacyCard>
           <h2 class="font-display text-[1.25rem] font-bold mb-4 tracking-tight">
@@ -115,7 +116,7 @@ import { GITHUB_URL } from "../config/constants";
             not for uploading your images.
           </p>
         </PrivacyCard>
-      </div>
+      </PageContainer>
     </section>
   </MarketingPageWrapper>
 </MarketingLayout>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -1,6 +1,8 @@
 ---
 import MarketingLayout from "../layouts/MarketingLayout.astro";
-import FloatingShapes from "../components/shared/FloatingShapes.astro";
+import MarketingPageWrapper from "../components/marketing/layout/MarketingPageWrapper.astro";
+import HeroSection from "../components/marketing/hero/HeroSection.astro";
+import PrivacyCard from "../components/marketing/cards/PrivacyCard.astro";
 import { GITHUB_URL } from "../config/constants";
 ---
 
@@ -9,190 +11,111 @@ import { GITHUB_URL } from "../config/constants";
   description="Reshrimp processes all images locally in your browser. No servers, no uploads, no tracking. Learn how it works."
   currentPath="/privacy"
 >
-  <div class="page-pop">
-    <FloatingShapes />
+  <MarketingPageWrapper>
+    <HeroSection
+      chip={{ label: "Privacy", variant: "mint" }}
+      title="Your images never leave your device."
+      subtitle="Reshrimp is built around local processing, minimal network use, and no image uploads."
+    />
 
-    <div transition:animate="fade">
-      <section class="privacy-hero">
-        <div class="privacy-container">
-          <span class="pop-chip pop-chip-mint">Privacy</span>
-          <h1 class="privacy-title">Your images never leave your device.</h1>
-          <p class="privacy-subtitle">
-            Reshrimp is built around local processing, minimal network use, and no image uploads.
+    <section class="px-8 py-8 pb-20 relative z-10">
+      <div class="max-w-[700px] mx-auto">
+        <!-- How it works -->
+        <PrivacyCard>
+          <h2 class="font-display text-[1.25rem] font-bold mb-4 tracking-tight">
+            How it works technically
+          </h2>
+          <p class="text-[0.95rem] text-sp-text-muted leading-[1.7] mb-4 last:mb-0">
+            When you select an image, it stays entirely in your browser's memory. Reshrimp uses
+            browser APIs to read, manipulate, and re-encode your image inside a single browser tab.
+            No image data is sent to any server during processing.
           </p>
-        </div>
-      </section>
+          <p class="text-[0.95rem] text-sp-text-muted leading-[1.7] mb-4 last:mb-0">
+            The processed image is generated as a Blob URL, which exists only in your browser's
+            memory. After the first online visit, the app shell and core tools can also load
+            offline. Background removal downloads its model assets the first time you use it, then
+            can run offline too.
+          </p>
+        </PrivacyCard>
 
-      <section class="privacy-content">
-        <div class="privacy-container">
-          <!-- How it works -->
-          <div class="privacy-card">
-            <h2 class="privacy-card-title">How it works technically</h2>
-            <p>
-              When you select an image, it stays entirely in your browser's memory. Reshrimp uses
-              browser APIs to read, manipulate, and re-encode your image inside a single browser
-              tab. No image data is sent to any server during processing.
-            </p>
-            <p>
-              The processed image is generated as a Blob URL, which exists only in your browser's
-              memory. After the first online visit, the app shell and core tools can also load
-              offline. Background removal downloads its model assets the first time you use it, then
-              can run offline too.
-            </p>
-          </div>
+        <!-- What we don't do -->
+        <PrivacyCard>
+          <h2 class="font-display text-[1.25rem] font-bold mb-4 tracking-tight">
+            What we don't do
+          </h2>
+          <ul class="list-none p-0 m-0 flex flex-col gap-[0.6rem]">
+            <li
+              class="text-[0.95rem] text-sp-text-muted leading-[1.6] pl-6 relative before:content-[''] before:absolute before:left-0 before:top-[0.55rem] before:w-2 before:h-2 before:rounded-full before:bg-sp-mint"
+            >
+              We don't upload your images anywhere
+            </li>
+            <li
+              class="text-[0.95rem] text-sp-text-muted leading-[1.6] pl-6 relative before:content-[''] before:absolute before:left-0 before:top-[0.55rem] before:w-2 before:h-2 before:rounded-full before:bg-sp-mint"
+            >
+              We don't use cookies or local storage for tracking
+            </li>
+            <li
+              class="text-[0.95rem] text-sp-text-muted leading-[1.6] pl-6 relative before:content-[''] before:absolute before:left-0 before:top-[0.55rem] before:w-2 before:h-2 before:rounded-full before:bg-sp-mint"
+            >
+              We don't run analytics scripts (no Google Analytics, no Plausible, nothing)
+            </li>
+            <li
+              class="text-[0.95rem] text-sp-text-muted leading-[1.6] pl-6 relative before:content-[''] before:absolute before:left-0 before:top-[0.55rem] before:w-2 before:h-2 before:rounded-full before:bg-sp-mint"
+            >
+              We don't require accounts or collect personal information
+            </li>
+            <li
+              class="text-[0.95rem] text-sp-text-muted leading-[1.6] pl-6 relative before:content-[''] before:absolute before:left-0 before:top-[0.55rem] before:w-2 before:h-2 before:rounded-full before:bg-sp-mint"
+            >
+              We don't upload your image data for processing
+            </li>
+            <li
+              class="text-[0.95rem] text-sp-text-muted leading-[1.6] pl-6 relative before:content-[''] before:absolute before:left-0 before:top-[0.55rem] before:w-2 before:h-2 before:rounded-full before:bg-sp-mint"
+            >
+              We don't fingerprint your browser or device
+            </li>
+          </ul>
+        </PrivacyCard>
 
-          <!-- What we don't do -->
-          <div class="privacy-card">
-            <h2 class="privacy-card-title">What we don't do</h2>
-            <ul class="privacy-list">
-              <li>We don't upload your images anywhere</li>
-              <li>We don't use cookies or local storage for tracking</li>
-              <li>We don't run analytics scripts (no Google Analytics, no Plausible, nothing)</li>
-              <li>We don't require accounts or collect personal information</li>
-              <li>We don't upload your image data for processing</li>
-              <li>We don't fingerprint your browser or device</li>
-            </ul>
-          </div>
+        <!-- Open source -->
+        <PrivacyCard>
+          <h2 class="font-display text-[1.25rem] font-bold mb-4 tracking-tight">
+            Open source verification
+          </h2>
+          <p class="text-[0.95rem] text-sp-text-muted leading-[1.7] mb-4 last:mb-0">
+            Don't take our word for it — read the source code. Reshrimp is fully open source under
+            the MIT license. Every line of code is available for inspection.
+          </p>
+          <p class="text-[0.95rem] text-sp-text-muted leading-[1.7] mb-4 last:mb-0">
+            The image processing and workflow logic lives in TypeScript services that you can
+            inspect directly. Check the
+            <a
+              href={GITHUB_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-sp-coral underline underline-offset-2 decoration-[rgba(255,107,107,0.3)] hover:decoration-sp-coral transition-[text-decoration-color]"
+              >GitHub repository</a
+            >
+            to verify our claims.
+          </p>
+        </PrivacyCard>
 
-          <!-- Open source -->
-          <div class="privacy-card">
-            <h2 class="privacy-card-title">Open source verification</h2>
-            <p>
-              Don't take our word for it — read the source code. Reshrimp is fully open source under
-              the MIT license. Every line of code is available for inspection.
-            </p>
-            <p>
-              The image processing and workflow logic lives in TypeScript services that you can
-              inspect directly. Check the
-              <a href={GITHUB_URL} target="_blank" rel="noopener noreferrer">GitHub repository</a>
-              to verify our claims.
-            </p>
-          </div>
-
-          <!-- Third-party services -->
-          <div class="privacy-card">
-            <h2 class="privacy-card-title">Third-party services</h2>
-            <p>
-              Reshrimp is deployed as a static site. The first visit needs a network connection to
-              load the app shell.
-            </p>
-            <p>
-              After that, the app shell and core tools work offline. Background removal may download
-              model files once before it can work offline. Those requests are for app or model
-              assets, not for uploading your images.
-            </p>
-          </div>
-        </div>
-      </section>
-    </div>
-  </div>
+        <!-- Third-party services -->
+        <PrivacyCard>
+          <h2 class="font-display text-[1.25rem] font-bold mb-4 tracking-tight">
+            Third-party services
+          </h2>
+          <p class="text-[0.95rem] text-sp-text-muted leading-[1.7] mb-4 last:mb-0">
+            Reshrimp is deployed as a static site. The first visit needs a network connection to
+            load the app shell.
+          </p>
+          <p class="text-[0.95rem] text-sp-text-muted leading-[1.7] mb-4 last:mb-0">
+            After that, the app shell and core tools work offline. Background removal may download
+            model files once before it can work offline. Those requests are for app or model assets,
+            not for uploading your images.
+          </p>
+        </PrivacyCard>
+      </div>
+    </section>
+  </MarketingPageWrapper>
 </MarketingLayout>
-
-<style>
-  .page-pop {
-    position: relative;
-    overflow-x: hidden;
-    min-height: 100vh;
-  }
-
-  .privacy-hero {
-    padding: 5rem 2rem 3rem;
-    text-align: center;
-    position: relative;
-    z-index: 1;
-  }
-
-  .privacy-container {
-    max-width: 700px;
-    margin: 0 auto;
-  }
-
-  .privacy-title {
-    font-family: var(--sp-font-display);
-    font-size: clamp(2rem, 5vw, 3rem);
-    font-weight: 800;
-    line-height: 1.15;
-    margin: 1rem 0 1.25rem;
-    letter-spacing: -0.03em;
-  }
-
-  .privacy-subtitle {
-    font-size: 1.05rem;
-    color: var(--sp-text-muted);
-    line-height: 1.7;
-    margin: 0;
-  }
-
-  .privacy-content {
-    padding: 2rem 2rem 5rem;
-    position: relative;
-    z-index: 1;
-  }
-
-  .privacy-card {
-    background: var(--sp-bg-card);
-    border: 1px solid var(--sp-border);
-    border-radius: var(--sp-radius-xl);
-    padding: 2rem;
-    box-shadow: var(--sp-shadow);
-    margin-bottom: 1.5rem;
-  }
-
-  .privacy-card-title {
-    font-family: var(--sp-font-display);
-    font-size: 1.25rem;
-    font-weight: 700;
-    margin: 0 0 1rem;
-    letter-spacing: -0.01em;
-  }
-
-  .privacy-card p {
-    font-size: 0.95rem;
-    color: var(--sp-text-muted);
-    line-height: 1.7;
-    margin: 0 0 1rem;
-  }
-
-  .privacy-card p:last-child {
-    margin-bottom: 0;
-  }
-
-  .privacy-card a {
-    color: var(--sp-coral);
-    text-decoration: underline;
-    text-decoration-color: rgba(255, 107, 107, 0.3);
-    text-underline-offset: 2px;
-  }
-
-  .privacy-card a:hover {
-    text-decoration-color: var(--sp-coral);
-  }
-
-  .privacy-list {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.6rem;
-  }
-
-  .privacy-list li {
-    font-size: 0.95rem;
-    color: var(--sp-text-muted);
-    line-height: 1.6;
-    padding-left: 1.5rem;
-    position: relative;
-  }
-
-  .privacy-list li::before {
-    content: "";
-    position: absolute;
-    left: 0;
-    top: 0.55rem;
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    background: var(--sp-mint);
-  }
-</style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -199,6 +199,47 @@ body {
   animation: pageEnter 0.3s cubic-bezier(0.22, 1, 0.36, 1) forwards;
 }
 
+/* ===== FAQ Accordion ===== */
+.faq-question::after {
+  content: "+";
+  font-size: 1.3rem;
+  font-weight: 400;
+  color: var(--sp-coral);
+  flex-shrink: 0;
+  transition: transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.faq-item.faq-open .faq-question::after {
+  transform: rotate(45deg);
+}
+
+.faq-item.faq-open .faq-body {
+  grid-template-rows: 1fr !important;
+}
+
+.faq-item.faq-open .faq-answer {
+  opacity: 1 !important;
+  transform: translateY(0) !important;
+}
+
+.faq-item.faq-open {
+  border-color: var(--sp-lavender) !important;
+  box-shadow: 0 4px 24px rgba(167, 139, 250, 0.14) !important;
+  transform: scale(1.008) !important;
+}
+
+.faq-answer a {
+  color: var(--sp-coral);
+  text-decoration: underline;
+  text-decoration-color: rgba(255, 107, 107, 0.3);
+  text-underline-offset: 2px;
+  transition: text-decoration-color 0.2s;
+}
+
+.faq-answer a:hover {
+  text-decoration-color: var(--sp-coral);
+}
+
 /* ===== Scroll Reveal ===== */
 [data-reveal] {
   opacity: 0;


### PR DESCRIPTION
## Summary

Refactor all marketing pages (/, /features, /about, /faq, /privacy, /changelog, /404) into focused, reusable, testable Astro components with centralized Tailwind styling, eliminating inline HTML bloat and enabling consistent UI evolution.

## Changes
- Create 18 reusable marketing components under `src/components/marketing/`: layout wrappers, hero sections, bento cards, feature rows, step flows, FAQ accordion, changelog releases, trust banners, CTA cards, content cards, and tech stack grids
- Refactor 7 pages (`index`, `about`, `features`, `faq`, `privacy`, `changelog`, `404`) to compose from the new components
- Replace inline SVGs with `lucide-astro` icons (ArrowRight, Github, ShieldCheck)
- Replace scoped `<style>` blocks with Tailwind utility classes across all marketing pages
- Move FAQ accordion interactive logic into a self-contained `FAQAccordion.astro` component with scoped script
- Add minimal FAQ accordion CSS to global.css for pseudo-element styles that can't be expressed in Tailwind
- Add Playwright e2e smoke tests for each marketing route

## Testing
- [x] `bun run verify` passes (type-check, lint, format, existing unit tests, build)
- [ ] E2E tests require Chromium system deps — run `npx playwright test` in CI

## Notes

The FAQ accordion uses a `::after` pseudo-element for the +/× toggle icon which is kept in global.css since it can't be expressed with Tailwind utilities. All other styling uses Tailwind classes exclusively.