### PR TITLE
fix: add aria-labelledby and keyboard navigation to FAQ accordion

### DIFF
--- a/src/components/marketing/sections/FAQAccordion.astro
+++ b/src/components/marketing/sections/FAQAccordion.astro
@@ -1,4 +1,6 @@
 ---
+import { createFaqId } from "@/lib/faqUtils";
+
 interface Props {
   question: string;
   answer: string;
@@ -6,6 +8,8 @@ interface Props {
 }
 
 const { question, answer, delay = 0 } = Astro.props;
+const buttonId = createFaqId(question);
+const panelId = `${buttonId}-panel`;
 ---
 
 <div
@@ -14,14 +18,19 @@ const { question, answer, delay = 0 } = Astro.props;
   data-reveal-delay={String(delay)}
 >
   <button
+    id={buttonId}
     class="faq-question w-full text-left font-display text-[1.05rem] font-semibold py-5 px-6 flex items-center justify-between gap-4 transition-colors duration-200 hover:text-sp-coral"
     aria-expanded="false"
+    aria-controls={panelId}
   >
-    {question}
+    <span>{question}</span>
+    <span class="sr-only faq-toggle-indicator">Expand answer</span>
   </button>
   <div
+    id={panelId}
     class="faq-body grid [grid-template-rows:0fr] transition-[grid-template-rows] duration-[400ms] [transition-timing-function:cubic-bezier(0.22,1,0.36,1)]"
     role="region"
+    aria-labelledby={buttonId}
   >
     <div class="overflow-hidden">
       <p
@@ -33,7 +42,8 @@ const { question, answer, delay = 0 } = Astro.props;
 </div>
 
 <script>
-  // Use event delegation so all FAQ items work regardless of how many component instances exist
+  import { handleFaqKeyboard } from "@/lib/faqKeyboard";
+
   function handleFaqClick(e: Event) {
     const question = (e.target as HTMLElement).closest(".faq-question");
     if (!question) return;
@@ -41,7 +51,12 @@ const { question, answer, delay = 0 } = Astro.props;
     if (!item) return;
     const isOpen = item.classList.toggle("faq-open");
     question.setAttribute("aria-expanded", String(isOpen));
+    const indicator = question.querySelector(".faq-toggle-indicator");
+    if (indicator) {
+      indicator.textContent = isOpen ? "Collapse answer" : "Expand answer";
+    }
   }
 
   document.addEventListener("click", handleFaqClick);
+  document.addEventListener("keydown", handleFaqKeyboard);
 </script>

--- a/src/lib/faqKeyboard.test.ts
+++ b/src/lib/faqKeyboard.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import { handleFaqKeyboard } from "./faqKeyboard";
+
+function createFaqDom() {
+  document.body.innerHTML = `
+    <div class="faq-item">
+      <button class="faq-question" id="faq-1">Question 1</button>
+      <div class="faq-body" role="region" id="faq-1-panel"></div>
+    </div>
+    <div class="faq-item">
+      <button class="faq-question" id="faq-2">Question 2</button>
+      <div class="faq-body" role="region" id="faq-2-panel"></div>
+    </div>
+    <div class="faq-item">
+      <button class="faq-question" id="faq-3">Question 3</button>
+      <div class="faq-body" role="region" id="faq-3-panel"></div>
+    </div>
+  `;
+}
+
+function fireKeydownOn(target: Element, key: string) {
+  (target as HTMLElement).focus();
+  let prevented = false;
+  const event = new KeyboardEvent("keydown", {
+    key,
+    bubbles: true,
+    cancelable: true,
+  });
+  (target as HTMLElement).addEventListener("keydown", (e) => {
+    prevented = handleFaqKeyboard(e);
+  });
+  (target as HTMLElement).dispatchEvent(event);
+  return { event, prevented };
+}
+
+describe("handleFaqKeyboard", () => {
+  it("moves focus from first to second question on ArrowDown", () => {
+    createFaqDom();
+    const btn1 = document.getElementById("faq-1")!;
+
+    fireKeydownOn(btn1, "ArrowDown");
+
+    expect(document.activeElement?.id).toBe("faq-2");
+  });
+
+  it("moves focus from second to first question on ArrowUp", () => {
+    createFaqDom();
+    const btn2 = document.getElementById("faq-2")!;
+
+    fireKeydownOn(btn2, "ArrowUp");
+
+    expect(document.activeElement?.id).toBe("faq-1");
+  });
+
+  it("moves focus to first question on Home", () => {
+    createFaqDom();
+    const btn3 = document.getElementById("faq-3")!;
+
+    fireKeydownOn(btn3, "Home");
+
+    expect(document.activeElement?.id).toBe("faq-1");
+  });
+
+  it("moves focus to last question on End", () => {
+    createFaqDom();
+    const btn1 = document.getElementById("faq-1")!;
+
+    fireKeydownOn(btn1, "End");
+
+    expect(document.activeElement?.id).toBe("faq-3");
+  });
+
+  it("does nothing when target is not a faq-question", () => {
+    createFaqDom();
+    const other = document.createElement("div");
+    document.body.appendChild(other);
+
+    let prevented = false;
+    const event = new KeyboardEvent("keydown", {
+      key: "ArrowDown",
+      bubbles: true,
+      cancelable: true,
+    });
+    other.addEventListener("keydown", (e) => {
+      prevented = handleFaqKeyboard(e);
+    });
+    other.dispatchEvent(event);
+
+    expect(prevented).toBe(false);
+  });
+
+  it("does nothing for unsupported keys", () => {
+    createFaqDom();
+    const btn1 = document.getElementById("faq-1")!;
+
+    fireKeydownOn(btn1, "a");
+
+    expect(document.activeElement?.id).toBe("faq-1");
+  });
+
+  it("prevents default for supported navigation keys", () => {
+    createFaqDom();
+    const btn1 = document.getElementById("faq-1")!;
+
+    const { prevented } = fireKeydownOn(btn1, "ArrowDown");
+
+    expect(prevented).toBe(true);
+  });
+
+  it("wraps ArrowDown past last item to first", () => {
+    createFaqDom();
+    const btn3 = document.getElementById("faq-3")!;
+
+    fireKeydownOn(btn3, "ArrowDown");
+
+    expect(document.activeElement?.id).toBe("faq-1");
+  });
+
+  it("wraps ArrowUp past first item to last", () => {
+    createFaqDom();
+    const btn1 = document.getElementById("faq-1")!;
+
+    fireKeydownOn(btn1, "ArrowUp");
+
+    expect(document.activeElement?.id).toBe("faq-3");
+  });
+});

--- a/src/lib/faqKeyboard.ts
+++ b/src/lib/faqKeyboard.ts
@@ -1,0 +1,39 @@
+export function handleFaqKeyboard(e: KeyboardEvent): boolean {
+  if (!e.target) return false;
+  const button = (e.target as HTMLElement).closest(".faq-question");
+  if (!button) return false;
+
+  const item = button.closest(".faq-item");
+  if (!item) return false;
+
+  const allItems = Array.from(document.querySelectorAll(".faq-item"));
+  const currentIndex = allItems.indexOf(item as HTMLElement);
+  if (currentIndex === -1) return false;
+
+  let nextIndex: number;
+
+  switch (e.key) {
+    case "ArrowDown":
+      nextIndex = currentIndex + 1 >= allItems.length ? 0 : currentIndex + 1;
+      break;
+    case "ArrowUp":
+      nextIndex = currentIndex - 1 < 0 ? allItems.length - 1 : currentIndex - 1;
+      break;
+    case "Home":
+      nextIndex = 0;
+      break;
+    case "End":
+      nextIndex = allItems.length - 1;
+      break;
+    default:
+      return false;
+  }
+
+  const nextButton = allItems[nextIndex].querySelector(".faq-question") as HTMLElement | null;
+  if (nextButton) {
+    nextButton.focus();
+  }
+
+  e.preventDefault();
+  return true;
+}

--- a/src/lib/faqUtils.test.ts
+++ b/src/lib/faqUtils.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { createFaqId } from "./faqUtils";
+
+describe("createFaqId", () => {
+  it("slugifies a simple question into a lowercase, hyphenated id", () => {
+    expect(createFaqId("What is Reshrimp")).toBe("what-is-reshrimp");
+  });
+
+  it("strips non-alphanumeric characters except hyphens", () => {
+    expect(createFaqId("Is it free? Yes!")).toBe("is-it-free-yes");
+  });
+
+  it("collapses multiple spaces and hyphens", () => {
+    expect(createFaqId("How   does  it work")).toBe("how-does-it-work");
+  });
+
+  it("trims leading/trailing whitespace", () => {
+    expect(createFaqId("  Where is my data stored?  ")).toBe("where-is-my-data-stored");
+  });
+
+  it("handles very short input", () => {
+    expect(createFaqId("Hi")).toBe("hi");
+  });
+});

--- a/src/lib/faqUtils.ts
+++ b/src/lib/faqUtils.ts
@@ -1,0 +1,8 @@
+export function createFaqId(question: string): string {
+  return question
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/[\s-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}


### PR DESCRIPTION
## Summary
Added `aria-labelledby` linking each FAQ button to its answer panel, screen-reader toggle indicator text, and Up/Down/Home/End arrow-key navigation between accordion items.

## Changes
- Added `createFaqId` utility to generate unique IDs from question text
- Added `handleFaqKeyboard` for ArrowUp/Down/Home/End keyboard navigation with wrapping
- Each FAQ button now has unique `id`, `aria-controls` pointing to its panel
- Each FAQ panel `<div role="region">` has `id` and `aria-labelledby` pointing back to its button
- Added sr-only text for expand/collapse state on toggle indicator
- Integrated keyboard handler via event delegation on the document

## Testing
**Automated**
- [x] `bun run test` passed (217 tests)

Closes #108