### PR TITLE
chore: extract shared Chip badge primitive and adopt everywhere

### DIFF
--- a/src/components/app/panels/ComingSoonPanel.tsx
+++ b/src/components/app/panels/ComingSoonPanel.tsx
@@ -1,4 +1,5 @@
 import type { LucideIcon } from "lucide-solid";
+import Chip from "@/components/ui/Chip";
 
 interface ComingSoonPanelProps {
   Icon: LucideIcon;
@@ -16,11 +17,7 @@ export default function ComingSoonPanel(props: ComingSoonPanelProps) {
         <h3 class="font-semibold text-[0.9rem] text-sp-text m-0">{props.title}</h3>
         <p class="text-[0.8rem] text-sp-text-soft leading-relaxed m-0">{props.description}</p>
       </div>
-      <div class="px-3 py-1 rounded-sp-full bg-sp-lavender-light">
-        <span class="text-[0.65rem] font-semibold text-sp-lavender-dark uppercase tracking-[0.1em]">
-          Coming in a future update
-        </span>
-      </div>
+      <Chip label="Coming in a future update" variant="lavender" size="sm" />
     </div>
   );
 }

--- a/src/components/marketing/hero/HeroSection.astro
+++ b/src/components/marketing/hero/HeroSection.astro
@@ -1,4 +1,6 @@
 ---
+import ChipComponent from "../../ui/Chip.astro";
+
 interface Chip {
   label: string;
   variant: "coral" | "mint" | "lavender" | "yellow";
@@ -14,12 +16,6 @@ interface Props {
 }
 
 const { chip, chips, title, subtitle, gradientTitle, centered = true } = Astro.props;
-const variantClasses: Record<string, string> = {
-  coral: "pop-chip-coral",
-  mint: "pop-chip-mint",
-  lavender: "pop-chip-lavender",
-  yellow: "pop-chip-yellow",
-};
 ---
 
 <section class:list={["px-8 py-20 relative z-10 md:px-5 md:py-12", { "text-center": centered }]}>
@@ -31,15 +27,12 @@ const variantClasses: Record<string, string> = {
           style="animation: popBounceIn 0.6s 0.1s forwards"
         >
           {chips.map((c) => (
-            <span class:list={["pop-chip", variantClasses[c.variant]]}>{c.label}</span>
+            <ChipComponent label={c.label} variant={c.variant} />
           ))}
         </div>
       ) : chip ? (
-        <span
-          class:list={["pop-chip", variantClasses[chip.variant]]}
-          style="animation: popBounceIn 0.6s 0.1s forwards"
-        >
-          {chip.label}
+        <span class="opacity-0" style="animation: popBounceIn 0.6s 0.1s forwards">
+          <ChipComponent label={chip.label} variant={chip.variant} />
         </span>
       ) : null
     }

--- a/src/components/marketing/sections/TrustBanner.astro
+++ b/src/components/marketing/sections/TrustBanner.astro
@@ -1,5 +1,6 @@
 ---
 import { ShieldCheck } from "lucide-astro";
+import Chip from "../../ui/Chip.astro";
 ---
 
 <section class="px-8 py-12 relative z-10">
@@ -20,26 +21,11 @@ import { ShieldCheck } from "lucide-astro";
         model assets are downloaded once. No uploads, accounts, or tracking.
       </p>
       <div class="flex justify-center flex-wrap gap-2">
-        <span
-          class="inline-block text-[0.7rem] font-semibold py-[0.3rem] px-[0.8rem] rounded-sp-full bg-sp-mint-light text-sp-mint-dark tracking-[0.01em]"
-          >No servers</span
-        >
-        <span
-          class="inline-block text-[0.7rem] font-semibold py-[0.3rem] px-[0.8rem] rounded-sp-full bg-sp-mint-light text-sp-mint-dark tracking-[0.01em]"
-          >No cookies</span
-        >
-        <span
-          class="inline-block text-[0.7rem] font-semibold py-[0.3rem] px-[0.8rem] rounded-sp-full bg-sp-mint-light text-sp-mint-dark tracking-[0.01em]"
-          >No analytics</span
-        >
-        <span
-          class="inline-block text-[0.7rem] font-semibold py-[0.3rem] px-[0.8rem] rounded-sp-full bg-sp-mint-light text-sp-mint-dark tracking-[0.01em]"
-          >No accounts</span
-        >
-        <span
-          class="inline-block text-[0.7rem] font-semibold py-[0.3rem] px-[0.8rem] rounded-sp-full bg-sp-mint-light text-sp-mint-dark tracking-[0.01em]"
-          >Open source</span
-        >
+        <Chip label="No servers" variant="mint" size="sm" />
+        <Chip label="No cookies" variant="mint" size="sm" />
+        <Chip label="No analytics" variant="mint" size="sm" />
+        <Chip label="No accounts" variant="mint" size="sm" />
+        <Chip label="Open source" variant="mint" size="sm" />
       </div>
     </div>
   </div>

--- a/src/components/ui/Chip.astro
+++ b/src/components/ui/Chip.astro
@@ -1,0 +1,12 @@
+---
+interface Props {
+  label: string;
+  variant: "coral" | "mint" | "lavender" | "yellow";
+  size?: "sm" | "default";
+}
+
+const { label, variant, size = "default" } = Astro.props;
+const sizeClass = size === "sm" ? "pop-chip-sm" : "";
+---
+
+<span class:list={["pop-chip", `pop-chip-${variant}`, sizeClass]}>{label}</span>

--- a/src/components/ui/Chip.tsx
+++ b/src/components/ui/Chip.tsx
@@ -1,0 +1,13 @@
+interface ChipProps {
+  label: string;
+  variant: "coral" | "mint" | "lavender" | "yellow";
+  size?: "sm" | "default";
+}
+
+export default function Chip(props: ChipProps) {
+  return (
+    <span class={`pop-chip pop-chip-${props.variant} ${props.size === "sm" ? "pop-chip-sm" : ""}`}>
+      {props.label}
+    </span>
+  );
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -305,6 +305,11 @@ body {
   color: #a16207;
 }
 
+.pop-chip-sm {
+  font-size: 0.7rem;
+  padding: 0.3rem 0.8rem;
+}
+
 /* ===== Card ===== */
 .sp-card {
   background: var(--sp-bg-card);


### PR DESCRIPTION
## Summary
Created a reusable Chip component (Astro + SolidJS) and replaced all inline chip implementations across marketing pages and the app shell.

## Changes
- Created `ui/Chip.astro` with `label`, `variant` (coral/mint/lavender/yellow), and `size` (sm/default) props
- Created `ui/Chip.tsx` SolidJS equivalent for app-shell usage
- Added `pop-chip-sm` CSS class for the smaller size variant
- Replaced inline `pop-chip` spans in `HeroSection.astro` (chips + chip props)
- Replaced 5 inline chip spans in `TrustBanner.astro` with `<Chip variant="mint" size="sm">`
- Replaced "Coming in a future update" badge in `ComingSoonPanel.tsx` with SolidJS `<Chip>`
- No bare `pop-chip-*` CSS classes remain outside the Chip component

## Testing
**Automated**
- [x] `bun run verify` passed (typecheck, lint, format, 203 tests, build)

Closes #104