### PR TITLE
chore: split ImageAppContext into focused modules for batch-mode reuse

### DIFF
--- a/src/components/app/state/ImageAppContext.tsx
+++ b/src/components/app/state/ImageAppContext.tsx
@@ -1,190 +1,51 @@
 import {
-  batch,
   createContext,
-  createEffect,
   createMemo,
   createSignal,
-  on,
   onCleanup,
   onMount,
   useContext,
-  type Accessor,
   type JSX,
 } from "solid-js";
 import type { ProcessedImage, ValidationResult, ImageFormat } from "@/types/image";
-import type { ProcessResult, ResizeUnit } from "@/types/processing";
-import { processImage, getImageMetadata } from "@/services/imageService";
+import type { ProcessResult } from "@/types/processing";
 import { preloadBackgroundRemoval } from "@/services/backgroundRemovalService";
-import {
-  downloadProcessedBlob,
-  replaceObjectUrl,
-  revokeImageUrls,
-} from "@/services/imageSessionService";
-import {
-  buildProcessOptions,
-  formatResizeValue,
-  getDimensionValuesForDpiChange,
-  getFormatStateForBackgroundRemoval,
-  getLinkedDimensionValues,
-  getPresetResizeValues,
-  rebaseDimensionValues,
-} from "@/services/imageWorkflowService";
-import { validateImageFile, generateDownloadFilename } from "@/services/validationService";
-import { formatFileSize, generateId, convertFromPx } from "@/utils/imageUtils";
-import { DEFAULT_DPI } from "@/config/constants";
+import { revokeImageUrls } from "@/services/imageSessionService";
+import { formatResizeValue } from "@/services/imageWorkflowService";
+import { formatFileSize, convertFromPx } from "@/utils/imageUtils";
 import { getInitialOutputFormat, supportsBrowserQualityControl } from "@/config/imageFormats";
-import { SOCIAL_MEDIA_PRESETS } from "@/config/presets";
+import { createDebouncedTask, scheduleIdleTask } from "@/lib/asyncUtils";
+import { useImageFormState } from "@/components/app/state/useImageFormState";
+import { createProcessingPipeline } from "@/services/imageProcessingPipeline";
+import type { AppState, AppActions, SizeDiff } from "@/components/app/state/appTypes";
 
-export interface SizeDiff {
-  text: string;
-  className: string;
-}
-
-function createDebouncedTask(fn: () => void, ms: number) {
-  let timer: ReturnType<typeof setTimeout> | undefined;
-
-  return {
-    run() {
-      if (timer !== undefined) clearTimeout(timer);
-      timer = setTimeout(fn, ms);
-    },
-    cancel() {
-      if (timer !== undefined) clearTimeout(timer);
-      timer = undefined;
-    },
-  };
-}
-
-function scheduleIdleTask(callback: () => void): () => void {
-  if (typeof window === "undefined") return () => {};
-
-  const idleWindow = window as Window & {
-    requestIdleCallback?: (callback: IdleRequestCallback, options?: IdleRequestOptions) => number;
-    cancelIdleCallback?: (handle: number) => void;
-  };
-
-  if (
-    typeof idleWindow.requestIdleCallback === "function" &&
-    typeof idleWindow.cancelIdleCallback === "function"
-  ) {
-    const id = idleWindow.requestIdleCallback(() => callback(), { timeout: 1500 });
-    return () => idleWindow.cancelIdleCallback?.(id);
-  }
-
-  const id = globalThis.setTimeout(callback, 300);
-  return () => globalThis.clearTimeout(id);
-}
-
-interface AppState {
-  currentImage: Accessor<ProcessedImage | null>;
-  processResult: Accessor<ProcessResult | null>;
-  isProcessing: Accessor<boolean>;
-  progressLabel: Accessor<string | null>;
-  error: Accessor<string | null>;
-  validation: Accessor<ValidationResult | null>;
-  isDragOver: Accessor<boolean>;
-  tooltipOpen: Accessor<boolean>;
-  dpiTooltipOpen: Accessor<boolean>;
-  widthValue: Accessor<string>;
-  heightValue: Accessor<string>;
-  maintainAspectRatio: Accessor<boolean>;
-  removeBackground: Accessor<boolean>;
-  formatValue: Accessor<string>;
-  previousFormatValue: Accessor<string>;
-  qualityValue: Accessor<number>;
-  resizeUnit: Accessor<ResizeUnit>;
-  dpiValue: Accessor<number>;
-  presetValue: Accessor<string>;
-  currentOutputFormat: Accessor<ImageFormat | null>;
-  qualityControlSupported: Accessor<boolean>;
-  controlsActive: Accessor<boolean>;
-  formatSelectDisabled: Accessor<boolean>;
-  downloadActive: Accessor<boolean>;
-  widthPlaceholder: Accessor<string>;
-  heightPlaceholder: Accessor<string>;
-  sizeDifference: Accessor<SizeDiff | null>;
-}
-
-interface AppActions {
-  handleFileUpload(file: File): Promise<void>;
-  handleDownload(): void;
-  handleRemoveBackgroundChange(checked: boolean): void;
-  handleUnitChange(unit: ResizeUnit): void;
-  handleDpiChange(dpi: number): void;
-  handlePresetChange(label: string): void;
-  handleWidthInput(val: string): void;
-  handleHeightInput(val: string): void;
-  handleAspectRatioChange(checked: boolean): void;
-  setIsDragOver(v: boolean): void;
-  setTooltipOpen(v: boolean): void;
-  setDpiTooltipOpen(v: boolean): void;
-  setFormatValue(v: string): void;
-  setQualityValue(v: number): void;
-}
+export type { SizeDiff } from "@/components/app/state/appTypes";
 
 const ImageAppContext = createContext<{ state: AppState; actions: AppActions }>();
 
 export function ImageAppProvider(props: { children: JSX.Element }) {
-  // ── Core image state ──────────────────────────────────────────────────────
   const [currentImage, setCurrentImage] = createSignal<ProcessedImage | null>(null);
   const [processResult, setProcessResult] = createSignal<ProcessResult | null>(null);
-
-  // ── Async / loading state ─────────────────────────────────────────────────
   const [isProcessing, setIsProcessing] = createSignal(false);
   const [progressLabel, setProgressLabel] = createSignal<string | null>(null);
-
-  // ── UI state ──────────────────────────────────────────────────────────────
   const [error, setError] = createSignal<string | null>(null);
   const [validation, setValidation] = createSignal<ValidationResult | null>(null);
   const [isDragOver, setIsDragOver] = createSignal(false);
   const [tooltipOpen, setTooltipOpen] = createSignal(false);
   const [dpiTooltipOpen, setDpiTooltipOpen] = createSignal(false);
 
-  // ── Form controls ─────────────────────────────────────────────────────────
-  const [widthValue, setWidthValue] = createSignal("");
-  const [heightValue, setHeightValue] = createSignal("");
-  const [maintainAspectRatio, setMaintainAspectRatio] = createSignal(true);
-  const [removeBackground, setRemoveBackground] = createSignal(false);
-  const [formatValue, setFormatValue] = createSignal("");
-  const [previousFormatValue, setPreviousFormatValue] = createSignal("");
-  const [qualityValue, setQualityValue] = createSignal(92);
+  const form = useImageFormState(currentImage);
 
-  // ── Resize unit controls ──────────────────────────────────────────────────
-  const [resizeUnit, setResizeUnit] = createSignal<ResizeUnit>("px");
-  const [dpiValue, setDpiValue] = createSignal(DEFAULT_DPI);
-  const [presetValue, setPresetValue] = createSignal("");
-
-  const debouncedProcess = createDebouncedTask(() => {
-    void handleProcess();
-  }, 400);
-
-  onCleanup(() => {
-    debouncedProcess.cancel();
-    revokeImageUrls(currentImage());
-  });
-
-  // ── Preload background removal WASM + model once the app is idle ─────────
-  onMount(() => {
-    const cancelIdleTask = scheduleIdleTask(() => {
-      void preloadBackgroundRemoval().catch(() => {
-        // Silently ignore preload failures — will retry on actual use.
-      });
-    });
-
-    onCleanup(cancelIdleTask);
-  });
-
-  // ── Derived signals ───────────────────────────────────────────────────────
   const controlsActive = createMemo(() => currentImage() !== null);
-  const formatSelectDisabled = createMemo(() => removeBackground());
+  const formatSelectDisabled = createMemo(() => form.removeBackground());
   const downloadActive = createMemo(() => processResult() !== null);
 
   const currentOutputFormat = createMemo<ImageFormat | null>(() => {
     const image = currentImage();
     if (!image) return null;
-    if (removeBackground()) return "image/png";
-    return formatValue()
-      ? (formatValue() as ImageFormat)
+    if (form.removeBackground()) return "image/png";
+    return form.formatValue()
+      ? (form.formatValue() as ImageFormat)
       : getInitialOutputFormat(image.metadata.format);
   });
 
@@ -197,16 +58,16 @@ export function ImageAppProvider(props: { children: JSX.Element }) {
     const img = currentImage();
     if (!img) return "Original";
     const px = img.metadata.width;
-    const display = convertFromPx(px, resizeUnit(), px, dpiValue());
-    return formatResizeValue(display, resizeUnit());
+    const display = convertFromPx(px, form.resizeUnit(), px, form.dpiValue());
+    return formatResizeValue(display, form.resizeUnit());
   });
 
   const heightPlaceholder = createMemo(() => {
     const img = currentImage();
     if (!img) return "Original";
     const px = img.metadata.height;
-    const display = convertFromPx(px, resizeUnit(), px, dpiValue());
-    return formatResizeValue(display, resizeUnit());
+    const display = convertFromPx(px, form.resizeUnit(), px, form.dpiValue());
+    return formatResizeValue(display, form.resizeUnit());
   });
 
   const sizeDifference = createMemo<SizeDiff | null>(() => {
@@ -222,302 +83,49 @@ export function ImageAppProvider(props: { children: JSX.Element }) {
     };
   });
 
-  // ── Core processing (internal) ────────────────────────────────────────────
-  async function handleProcess(): Promise<void> {
-    const img = currentImage();
-    if (!img || isProcessing()) return;
+  const pipeline = createProcessingPipeline({
+    currentImage,
+    setCurrentImage,
+    processResult,
+    setProcessResult,
+    isProcessing,
+    setIsProcessing,
+    setProgressLabel,
+    setError,
+    setValidation,
+    setTooltipOpen,
+    setDpiTooltipOpen,
+    widthValue: form.widthValue,
+    heightValue: form.heightValue,
+    maintainAspectRatio: form.maintainAspectRatio,
+    removeBackground: form.removeBackground,
+    formatValue: form.formatValue,
+    qualityValue: form.qualityValue,
+    resizeUnit: form.resizeUnit,
+    dpiValue: form.dpiValue,
+    presetValue: form.presetValue,
+    currentOutputFormat,
+    qualityControlSupported,
+    resetFormControls: form.resetFormControls,
+  });
 
-    const options = buildProcessOptions({
-      originalWidth: img.metadata.width,
-      originalHeight: img.metadata.height,
-      widthValue: widthValue(),
-      heightValue: heightValue(),
-      maintainAspectRatio: maintainAspectRatio(),
-      removeBackground: removeBackground(),
-      formatValue: formatValue(),
-      qualityValue: qualityValue(),
-      resizeUnit: resizeUnit(),
-      dpi: dpiValue(),
+  const debouncedProcess = createDebouncedTask(() => {
+    void pipeline.handleProcess();
+  }, 400);
+
+  pipeline.setupAutoProcessEffect(debouncedProcess);
+
+  onCleanup(() => {
+    debouncedProcess.cancel();
+    revokeImageUrls(currentImage());
+  });
+
+  onMount(() => {
+    const cancelIdleTask = scheduleIdleTask(() => {
+      void preloadBackgroundRemoval().catch(() => {});
     });
-
-    setIsProcessing(true);
-    setError(null);
-
-    if (options.removeBackground) {
-      setProgressLabel("Removing background\u2026");
-    }
-
-    try {
-      const result = await processImage(
-        img.file,
-        options,
-        options.removeBackground
-          ? (progress: number) => {
-              const pct = Math.round(progress * 100);
-              setProgressLabel(`Removing background ${pct}%\u2026`);
-            }
-          : undefined
-      );
-
-      const processedUrl = replaceObjectUrl(img.processedUrl, result.blob);
-
-      // Batch result updates into a single DOM update
-      batch(() => {
-        setCurrentImage((prev) => (prev ? { ...prev, processedUrl } : null));
-        setProcessResult(result);
-      });
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Processing failed");
-      console.error("Error processing image:", err);
-    } finally {
-      batch(() => {
-        setIsProcessing(false);
-        setProgressLabel(null);
-      });
-    }
-  }
-
-  // ── Auto-process: debounce fast operations, immediate for bg removal ──────
-  createEffect(
-    on(
-      [
-        currentImage,
-        widthValue,
-        heightValue,
-        formatValue,
-        () => (qualityControlSupported() ? qualityValue() : null),
-        resizeUnit,
-        dpiValue,
-        presetValue,
-        maintainAspectRatio,
-        removeBackground,
-      ],
-      ([image, , , , , , , , , shouldRemoveBackground]) => {
-        if (!image) return;
-
-        if (shouldRemoveBackground) {
-          void handleProcess();
-          return;
-        }
-
-        debouncedProcess.run();
-      },
-      { defer: true }
-    )
-  );
-
-  // ── Handlers ──────────────────────────────────────────────────────────────
-  async function handleFileUpload(file: File): Promise<void> {
-    const validationResult = validateImageFile(file);
-    setValidation(validationResult);
-
-    if (!validationResult.valid) return;
-
-    try {
-      const metadata = await getImageMetadata(file);
-      const originalUrl = URL.createObjectURL(file);
-
-      const processedImage: ProcessedImage = {
-        id: generateId(),
-        file,
-        originalUrl,
-        processedUrl: null,
-        metadata,
-        processing: false,
-        error: null,
-      };
-
-      // Batch all state resets into a single DOM update to prevent flickering.
-      // Without batch(), each set* after an await triggers a separate re-render.
-      batch(() => {
-        // Reset stale state when a new file is loaded
-        setCurrentImage((previousImage) => {
-          revokeImageUrls(previousImage);
-          return processedImage;
-        });
-        setProcessResult(null);
-        setError(null);
-
-        // Reset form controls to defaults
-        setWidthValue("");
-        setHeightValue("");
-        setMaintainAspectRatio(true);
-        setRemoveBackground(false);
-        setFormatValue(getInitialOutputFormat(metadata.format));
-        setPreviousFormatValue("");
-        setQualityValue(92);
-        setTooltipOpen(false);
-
-        // Reset unit controls
-        setResizeUnit("px");
-        setDpiValue(DEFAULT_DPI);
-        setPresetValue("");
-        setDpiTooltipOpen(false);
-      });
-    } catch (err) {
-      setError("Failed to load image. Please try another file.");
-      console.error("Error loading image:", err);
-    }
-  }
-
-  function handleDownload(): void {
-    const img = currentImage();
-    const result = processResult();
-    if (!img?.processedUrl || !result) return;
-
-    const targetFormat = currentOutputFormat();
-    if (!targetFormat) return;
-
-    const filename = generateDownloadFilename(img.metadata.fileName, targetFormat);
-
-    try {
-      downloadProcessedBlob(result.blob, filename);
-    } catch (err) {
-      setError("Failed to download image");
-      console.error("Download error:", err);
-    }
-  }
-
-  function handleRemoveBackgroundChange(checked: boolean): void {
-    const nextFormatState = getFormatStateForBackgroundRemoval({
-      checked,
-      formatValue: formatValue(),
-      previousFormatValue: previousFormatValue(),
-    });
-
-    setPreviousFormatValue(nextFormatState.previousFormatValue);
-    setFormatValue(nextFormatState.formatValue);
-    setRemoveBackground(checked);
-  }
-
-  function handleUnitChange(newUnit: ResizeUnit): void {
-    const img = currentImage();
-
-    if (img) {
-      const nextDimensions = rebaseDimensionValues({
-        widthValue: widthValue(),
-        heightValue: heightValue(),
-        oldUnit: resizeUnit(),
-        newUnit,
-        originalWidth: img.metadata.width,
-        originalHeight: img.metadata.height,
-        dpi: dpiValue(),
-      });
-
-      setWidthValue(nextDimensions.widthValue);
-      setHeightValue(nextDimensions.heightValue);
-    }
-
-    setResizeUnit(newUnit);
-  }
-
-  function handleDpiChange(newDpi: number): void {
-    const img = currentImage();
-
-    if (img) {
-      const nextDimensions = getDimensionValuesForDpiChange({
-        widthValue: widthValue(),
-        heightValue: heightValue(),
-        resizeUnit: resizeUnit(),
-        originalWidth: img.metadata.width,
-        originalHeight: img.metadata.height,
-        previousDpi: dpiValue(),
-        nextDpi: newDpi,
-      });
-
-      setWidthValue(nextDimensions.widthValue);
-      setHeightValue(nextDimensions.heightValue);
-    }
-
-    setDpiValue(newDpi);
-  }
-
-  function handlePresetChange(label: string): void {
-    setPresetValue(label);
-    if (!label) return;
-
-    const presetValues = getPresetResizeValues(label, SOCIAL_MEDIA_PRESETS);
-    if (!presetValues) return;
-
-    setResizeUnit(presetValues.resizeUnit);
-    setWidthValue(presetValues.widthValue);
-    setHeightValue(presetValues.heightValue);
-  }
-
-  function handleWidthInput(val: string): void {
-    setPresetValue("");
-
-    if (!maintainAspectRatio()) {
-      setWidthValue(val);
-      return;
-    }
-
-    const img = currentImage();
-    if (!img) {
-      setWidthValue(val);
-      return;
-    }
-
-    const linkedDimensions = getLinkedDimensionValues({
-      changedDimension: "width",
-      value: val,
-      resizeUnit: resizeUnit(),
-      dpi: dpiValue(),
-      originalWidth: img.metadata.width,
-      originalHeight: img.metadata.height,
-    });
-
-    if (!linkedDimensions) {
-      setWidthValue(val);
-      return;
-    }
-
-    setWidthValue(linkedDimensions.widthValue);
-    setHeightValue(linkedDimensions.heightValue);
-  }
-
-  function handleHeightInput(val: string): void {
-    setPresetValue("");
-
-    if (!maintainAspectRatio()) {
-      setHeightValue(val);
-      return;
-    }
-
-    const img = currentImage();
-    if (!img) {
-      setHeightValue(val);
-      return;
-    }
-
-    const linkedDimensions = getLinkedDimensionValues({
-      changedDimension: "height",
-      value: val,
-      resizeUnit: resizeUnit(),
-      dpi: dpiValue(),
-      originalWidth: img.metadata.width,
-      originalHeight: img.metadata.height,
-    });
-
-    if (!linkedDimensions) {
-      setHeightValue(val);
-      return;
-    }
-
-    setWidthValue(linkedDimensions.widthValue);
-    setHeightValue(linkedDimensions.heightValue);
-  }
-
-  function handleAspectRatioChange(checked: boolean): void {
-    setMaintainAspectRatio(checked);
-    if (checked) {
-      if (widthValue()) {
-        handleWidthInput(widthValue());
-      } else if (heightValue()) {
-        handleHeightInput(heightValue());
-      }
-    }
-  }
+    onCleanup(cancelIdleTask);
+  });
 
   const state: AppState = {
     currentImage,
@@ -529,16 +137,16 @@ export function ImageAppProvider(props: { children: JSX.Element }) {
     isDragOver,
     tooltipOpen,
     dpiTooltipOpen,
-    widthValue,
-    heightValue,
-    maintainAspectRatio,
-    removeBackground,
-    formatValue,
-    previousFormatValue,
-    qualityValue,
-    resizeUnit,
-    dpiValue,
-    presetValue,
+    widthValue: form.widthValue,
+    heightValue: form.heightValue,
+    maintainAspectRatio: form.maintainAspectRatio,
+    removeBackground: form.removeBackground,
+    formatValue: form.formatValue,
+    previousFormatValue: form.previousFormatValue,
+    qualityValue: form.qualityValue,
+    resizeUnit: form.resizeUnit,
+    dpiValue: form.dpiValue,
+    presetValue: form.presetValue,
     currentOutputFormat,
     qualityControlSupported,
     controlsActive,
@@ -550,20 +158,20 @@ export function ImageAppProvider(props: { children: JSX.Element }) {
   };
 
   const actions: AppActions = {
-    handleFileUpload,
-    handleDownload,
-    handleRemoveBackgroundChange,
-    handleUnitChange,
-    handleDpiChange,
-    handlePresetChange,
-    handleWidthInput,
-    handleHeightInput,
-    handleAspectRatioChange,
+    handleFileUpload: pipeline.handleFileUpload,
+    handleDownload: pipeline.handleDownload,
+    handleRemoveBackgroundChange: form.handleRemoveBackgroundChange,
+    handleUnitChange: form.handleUnitChange,
+    handleDpiChange: form.handleDpiChange,
+    handlePresetChange: form.handlePresetChange,
+    handleWidthInput: form.handleWidthInput,
+    handleHeightInput: form.handleHeightInput,
+    handleAspectRatioChange: form.handleAspectRatioChange,
     setIsDragOver,
     setTooltipOpen,
     setDpiTooltipOpen,
-    setFormatValue,
-    setQualityValue,
+    setFormatValue: form.setFormatValue,
+    setQualityValue: form.setQualityValue,
   };
 
   return (

--- a/src/components/app/state/appTypes.ts
+++ b/src/components/app/state/appTypes.ts
@@ -1,0 +1,55 @@
+import type { Accessor } from "solid-js";
+import type { ProcessedImage, ValidationResult, ImageFormat } from "@/types/image";
+import type { ProcessResult, ResizeUnit } from "@/types/processing";
+
+export interface SizeDiff {
+  text: string;
+  className: string;
+}
+
+export interface AppState {
+  currentImage: Accessor<ProcessedImage | null>;
+  processResult: Accessor<ProcessResult | null>;
+  isProcessing: Accessor<boolean>;
+  progressLabel: Accessor<string | null>;
+  error: Accessor<string | null>;
+  validation: Accessor<ValidationResult | null>;
+  isDragOver: Accessor<boolean>;
+  tooltipOpen: Accessor<boolean>;
+  dpiTooltipOpen: Accessor<boolean>;
+  widthValue: Accessor<string>;
+  heightValue: Accessor<string>;
+  maintainAspectRatio: Accessor<boolean>;
+  removeBackground: Accessor<boolean>;
+  formatValue: Accessor<string>;
+  previousFormatValue: Accessor<string>;
+  qualityValue: Accessor<number>;
+  resizeUnit: Accessor<ResizeUnit>;
+  dpiValue: Accessor<number>;
+  presetValue: Accessor<string>;
+  currentOutputFormat: Accessor<ImageFormat | null>;
+  qualityControlSupported: Accessor<boolean>;
+  controlsActive: Accessor<boolean>;
+  formatSelectDisabled: Accessor<boolean>;
+  downloadActive: Accessor<boolean>;
+  widthPlaceholder: Accessor<string>;
+  heightPlaceholder: Accessor<string>;
+  sizeDifference: Accessor<SizeDiff | null>;
+}
+
+export interface AppActions {
+  handleFileUpload(file: File): Promise<void>;
+  handleDownload(): void;
+  handleRemoveBackgroundChange(checked: boolean): void;
+  handleUnitChange(unit: ResizeUnit): void;
+  handleDpiChange(dpi: number): void;
+  handlePresetChange(label: string): void;
+  handleWidthInput(val: string): void;
+  handleHeightInput(val: string): void;
+  handleAspectRatioChange(checked: boolean): void;
+  setIsDragOver(v: boolean): void;
+  setTooltipOpen(v: boolean): void;
+  setDpiTooltipOpen(v: boolean): void;
+  setFormatValue(v: string): void;
+  setQualityValue(v: number): void;
+}

--- a/src/components/app/state/useImageFormState.ts
+++ b/src/components/app/state/useImageFormState.ts
@@ -1,0 +1,204 @@
+import { createSignal } from "solid-js";
+import type { ImageFormat } from "@/types/image";
+import type { ResizeUnit } from "@/types/processing";
+import { DEFAULT_DPI } from "@/config/constants";
+import {
+  getLinkedDimensionValues,
+  getFormatStateForBackgroundRemoval,
+  rebaseDimensionValues,
+  getDimensionValuesForDpiChange,
+  getPresetResizeValues,
+} from "@/services/imageWorkflowService";
+import { SOCIAL_MEDIA_PRESETS } from "@/config/presets";
+import type { Accessor } from "solid-js";
+import type { ProcessedImage } from "@/types/image";
+
+export function useImageFormState(currentImage: Accessor<ProcessedImage | null>) {
+  const [widthValue, setWidthValue] = createSignal("");
+  const [heightValue, setHeightValue] = createSignal("");
+  const [maintainAspectRatio, setMaintainAspectRatio] = createSignal(true);
+  const [removeBackground, setRemoveBackground] = createSignal(false);
+  const [formatValue, setFormatValue] = createSignal("");
+  const [previousFormatValue, setPreviousFormatValue] = createSignal("");
+  const [qualityValue, setQualityValue] = createSignal(92);
+  const [resizeUnit, setResizeUnit] = createSignal<ResizeUnit>("px");
+  const [dpiValue, setDpiValue] = createSignal(DEFAULT_DPI);
+  const [presetValue, setPresetValue] = createSignal("");
+
+  function handleRemoveBackgroundChange(checked: boolean): void {
+    const nextFormatState = getFormatStateForBackgroundRemoval({
+      checked,
+      formatValue: formatValue(),
+      previousFormatValue: previousFormatValue(),
+    });
+
+    setPreviousFormatValue(nextFormatState.previousFormatValue);
+    setFormatValue(nextFormatState.formatValue);
+    setRemoveBackground(checked);
+  }
+
+  function handleUnitChange(newUnit: ResizeUnit): void {
+    const img = currentImage();
+
+    if (img) {
+      const nextDimensions = rebaseDimensionValues({
+        widthValue: widthValue(),
+        heightValue: heightValue(),
+        oldUnit: resizeUnit(),
+        newUnit,
+        originalWidth: img.metadata.width,
+        originalHeight: img.metadata.height,
+        dpi: dpiValue(),
+      });
+
+      setWidthValue(nextDimensions.widthValue);
+      setHeightValue(nextDimensions.heightValue);
+    }
+
+    setResizeUnit(newUnit);
+  }
+
+  function handleDpiChange(newDpi: number): void {
+    const img = currentImage();
+
+    if (img) {
+      const nextDimensions = getDimensionValuesForDpiChange({
+        widthValue: widthValue(),
+        heightValue: heightValue(),
+        resizeUnit: resizeUnit(),
+        originalWidth: img.metadata.width,
+        originalHeight: img.metadata.height,
+        previousDpi: dpiValue(),
+        nextDpi: newDpi,
+      });
+
+      setWidthValue(nextDimensions.widthValue);
+      setHeightValue(nextDimensions.heightValue);
+    }
+
+    setDpiValue(newDpi);
+  }
+
+  function handlePresetChange(label: string): void {
+    setPresetValue(label);
+    if (!label) return;
+
+    const presetValues = getPresetResizeValues(label, SOCIAL_MEDIA_PRESETS);
+    if (!presetValues) return;
+
+    setResizeUnit(presetValues.resizeUnit);
+    setWidthValue(presetValues.widthValue);
+    setHeightValue(presetValues.heightValue);
+  }
+
+  function handleWidthInput(val: string): void {
+    setPresetValue("");
+
+    if (!maintainAspectRatio()) {
+      setWidthValue(val);
+      return;
+    }
+
+    const img = currentImage();
+    if (!img) {
+      setWidthValue(val);
+      return;
+    }
+
+    const linkedDimensions = getLinkedDimensionValues({
+      changedDimension: "width",
+      value: val,
+      resizeUnit: resizeUnit(),
+      dpi: dpiValue(),
+      originalWidth: img.metadata.width,
+      originalHeight: img.metadata.height,
+    });
+
+    if (!linkedDimensions) {
+      setWidthValue(val);
+      return;
+    }
+
+    setWidthValue(linkedDimensions.widthValue);
+    setHeightValue(linkedDimensions.heightValue);
+  }
+
+  function handleHeightInput(val: string): void {
+    setPresetValue("");
+
+    if (!maintainAspectRatio()) {
+      setHeightValue(val);
+      return;
+    }
+
+    const img = currentImage();
+    if (!img) {
+      setHeightValue(val);
+      return;
+    }
+
+    const linkedDimensions = getLinkedDimensionValues({
+      changedDimension: "height",
+      value: val,
+      resizeUnit: resizeUnit(),
+      dpi: dpiValue(),
+      originalWidth: img.metadata.width,
+      originalHeight: img.metadata.height,
+    });
+
+    if (!linkedDimensions) {
+      setHeightValue(val);
+      return;
+    }
+
+    setWidthValue(linkedDimensions.widthValue);
+    setHeightValue(linkedDimensions.heightValue);
+  }
+
+  function handleAspectRatioChange(checked: boolean): void {
+    setMaintainAspectRatio(checked);
+    if (checked) {
+      if (widthValue()) {
+        handleWidthInput(widthValue());
+      } else if (heightValue()) {
+        handleHeightInput(heightValue());
+      }
+    }
+  }
+
+  function resetFormControls(initialFormat: ImageFormat): void {
+    setWidthValue("");
+    setHeightValue("");
+    setMaintainAspectRatio(true);
+    setRemoveBackground(false);
+    setFormatValue(initialFormat);
+    setPreviousFormatValue("");
+    setQualityValue(92);
+    setResizeUnit("px");
+    setDpiValue(DEFAULT_DPI);
+    setPresetValue("");
+  }
+
+  return {
+    widthValue,
+    heightValue,
+    maintainAspectRatio,
+    removeBackground,
+    formatValue,
+    previousFormatValue,
+    qualityValue,
+    resizeUnit,
+    dpiValue,
+    presetValue,
+    handleRemoveBackgroundChange,
+    handleUnitChange,
+    handleDpiChange,
+    handlePresetChange,
+    handleWidthInput,
+    handleHeightInput,
+    handleAspectRatioChange,
+    setFormatValue,
+    setQualityValue,
+    resetFormControls,
+  };
+}

--- a/src/lib/asyncUtils.test.ts
+++ b/src/lib/asyncUtils.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+import { createDebouncedTask } from "./asyncUtils";
+
+describe("createDebouncedTask", () => {
+  it("calls the function after the specified delay", () => {
+    vi.useFakeTimers();
+    const fn = vi.fn();
+    const task = createDebouncedTask(fn, 100);
+
+    task.run();
+    expect(fn).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(99);
+    expect(fn).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    vi.useRealTimers();
+  });
+
+  it("debounces: resets the timer on subsequent calls", () => {
+    vi.useFakeTimers();
+    const fn = vi.fn();
+    const task = createDebouncedTask(fn, 100);
+
+    task.run();
+    vi.advanceTimersByTime(50);
+    task.run();
+    vi.advanceTimersByTime(50);
+
+    expect(fn).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(50);
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    vi.useRealTimers();
+  });
+
+  it("cancel prevents the function from being called", () => {
+    vi.useFakeTimers();
+    const fn = vi.fn();
+    const task = createDebouncedTask(fn, 100);
+
+    task.run();
+    task.cancel();
+    vi.advanceTimersByTime(200);
+
+    expect(fn).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+});

--- a/src/lib/asyncUtils.ts
+++ b/src/lib/asyncUtils.ts
@@ -1,0 +1,34 @@
+export function createDebouncedTask(fn: () => void, ms: number) {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  return {
+    run() {
+      if (timer !== undefined) clearTimeout(timer);
+      timer = setTimeout(fn, ms);
+    },
+    cancel() {
+      if (timer !== undefined) clearTimeout(timer);
+      timer = undefined;
+    },
+  };
+}
+
+export function scheduleIdleTask(callback: () => void): () => void {
+  if (typeof window === "undefined") return () => {};
+
+  const idleWindow = window as Window & {
+    requestIdleCallback?: (callback: IdleRequestCallback, options?: IdleRequestOptions) => number;
+    cancelIdleCallback?: (handle: number) => void;
+  };
+
+  if (
+    typeof idleWindow.requestIdleCallback === "function" &&
+    typeof idleWindow.cancelIdleCallback === "function"
+  ) {
+    const id = idleWindow.requestIdleCallback(() => callback(), { timeout: 1500 });
+    return () => idleWindow.cancelIdleCallback?.(id);
+  }
+
+  const id = globalThis.setTimeout(callback, 300);
+  return () => globalThis.clearTimeout(id);
+}

--- a/src/services/imageProcessingPipeline.ts
+++ b/src/services/imageProcessingPipeline.ts
@@ -1,0 +1,182 @@
+import { batch, createEffect, on, type Accessor, type Setter } from "solid-js";
+import type { ProcessedImage, ValidationResult } from "@/types/image";
+import type { ProcessResult, ResizeUnit } from "@/types/processing";
+import { processImage, getImageMetadata } from "@/services/imageService";
+import { buildProcessOptions } from "@/services/imageWorkflowService";
+import {
+  downloadProcessedBlob,
+  replaceObjectUrl,
+  revokeImageUrls,
+} from "@/services/imageSessionService";
+import { generateDownloadFilename, validateImageFile } from "@/services/validationService";
+import { generateId } from "@/utils/imageUtils";
+import { getInitialOutputFormat } from "@/config/imageFormats";
+import type { ImageFormat } from "@/types/image";
+
+interface PipelineDeps {
+  currentImage: Accessor<ProcessedImage | null>;
+  setCurrentImage: Setter<ProcessedImage | null>;
+  processResult: Accessor<ProcessResult | null>;
+  setProcessResult: Setter<ProcessResult | null>;
+  isProcessing: Accessor<boolean>;
+  setIsProcessing: Setter<boolean>;
+  setProgressLabel: Setter<string | null>;
+  setError: Setter<string | null>;
+  setValidation: Setter<ValidationResult | null>;
+  setTooltipOpen: Setter<boolean>;
+  setDpiTooltipOpen: Setter<boolean>;
+  widthValue: Accessor<string>;
+  heightValue: Accessor<string>;
+  maintainAspectRatio: Accessor<boolean>;
+  removeBackground: Accessor<boolean>;
+  formatValue: Accessor<string>;
+  qualityValue: Accessor<number>;
+  resizeUnit: Accessor<ResizeUnit>;
+  dpiValue: Accessor<number>;
+  presetValue: Accessor<string>;
+  currentOutputFormat: Accessor<ImageFormat | null>;
+  qualityControlSupported: Accessor<boolean>;
+  resetFormControls: (initialFormat: ImageFormat) => void;
+}
+
+export function createProcessingPipeline(deps: PipelineDeps) {
+  async function handleProcess(): Promise<void> {
+    const img = deps.currentImage();
+    if (!img || deps.isProcessing()) return;
+
+    const options = buildProcessOptions({
+      originalWidth: img.metadata.width,
+      originalHeight: img.metadata.height,
+      widthValue: deps.widthValue(),
+      heightValue: deps.heightValue(),
+      maintainAspectRatio: deps.maintainAspectRatio(),
+      removeBackground: deps.removeBackground(),
+      formatValue: deps.formatValue(),
+      qualityValue: deps.qualityValue(),
+      resizeUnit: deps.resizeUnit(),
+      dpi: deps.dpiValue(),
+    });
+
+    deps.setIsProcessing(true);
+    deps.setError(null);
+
+    if (options.removeBackground) {
+      deps.setProgressLabel("Removing background\u2026");
+    }
+
+    try {
+      const result = await processImage(
+        img.file,
+        options,
+        options.removeBackground
+          ? (progress: number) => {
+              const pct = Math.round(progress * 100);
+              deps.setProgressLabel(`Removing background ${pct}%\u2026`);
+            }
+          : undefined
+      );
+
+      const processedUrl = replaceObjectUrl(img.processedUrl, result.blob);
+
+      batch(() => {
+        deps.setCurrentImage((prev) => (prev ? { ...prev, processedUrl } : null));
+        deps.setProcessResult(result);
+      });
+    } catch (err) {
+      deps.setError(err instanceof Error ? err.message : "Processing failed");
+      console.error("Error processing image:", err);
+    } finally {
+      batch(() => {
+        deps.setIsProcessing(false);
+        deps.setProgressLabel(null);
+      });
+    }
+  }
+
+  function setupAutoProcessEffect(debouncedProcess: { run(): void }) {
+    createEffect(
+      on(
+        [
+          deps.currentImage,
+          deps.widthValue,
+          deps.heightValue,
+          deps.formatValue,
+          () => (deps.qualityControlSupported() ? deps.qualityValue() : null),
+          deps.resizeUnit,
+          deps.dpiValue,
+          deps.presetValue,
+          deps.maintainAspectRatio,
+          deps.removeBackground,
+        ],
+        ([image, , , , , , , , , shouldRemoveBackground]) => {
+          if (!image) return;
+
+          if (shouldRemoveBackground) {
+            void handleProcess();
+            return;
+          }
+
+          debouncedProcess.run();
+        },
+        { defer: true }
+      )
+    );
+  }
+
+  async function handleFileUpload(file: File): Promise<void> {
+    const validationResult = validateImageFile(file);
+    deps.setValidation(validationResult);
+
+    if (!validationResult.valid) return;
+
+    try {
+      const metadata = await getImageMetadata(file);
+      const originalUrl = URL.createObjectURL(file);
+
+      const processedImage: ProcessedImage = {
+        id: generateId(),
+        file,
+        originalUrl,
+        processedUrl: null,
+        metadata,
+        processing: false,
+        error: null,
+      };
+
+      batch(() => {
+        deps.setCurrentImage((previousImage) => {
+          revokeImageUrls(previousImage);
+          return processedImage;
+        });
+        deps.setProcessResult(null);
+        deps.setError(null);
+        deps.resetFormControls(getInitialOutputFormat(metadata.format));
+        deps.setTooltipOpen(false);
+        deps.setDpiTooltipOpen(false);
+      });
+    } catch (err) {
+      deps.setError("Failed to load image. Please try another file.");
+      console.error("Error loading image:", err);
+    }
+  }
+
+  function handleDownload(): void {
+    const img = deps.currentImage();
+    const result = deps.processResult();
+    if (!img?.processedUrl || !result) return;
+
+    const targetFormat = deps.currentOutputFormat();
+    if (!targetFormat) return;
+
+    const filename = generateDownloadFilename(img.metadata.fileName, targetFormat);
+
+    try {
+      downloadProcessedBlob(result.blob, filename);
+    } catch (err) {
+      deps.setError("Failed to download image");
+      console.error("Download error:", err);
+    }
+  }
+
+  return { handleProcess, setupAutoProcessEffect, handleFileUpload, handleDownload };
+}


### PR DESCRIPTION
## Summary
Broke the monolithic 580-line ImageAppContext into focused, independently reusable modules. Extracted async utilities, form control state, and processing pipeline so batch mode can reuse state management without duplicating the entire provider.

## Changes
- Extracted `createDebouncedTask` and `scheduleIdleTask` into `src/lib/asyncUtils.ts` with unit tests
- Extracted form control state into `useImageFormState` SolidJS hook in `src/components/app/state/`
- Extracted processing pipeline (`handleProcess`, `handleFileUpload`, `handleDownload`, auto-process effect) into `src/services/imageProcessingPipeline.ts`
- Moved AppState/AppActions/SizeDiff interfaces to `src/components/app/state/appTypes.ts`
- ImageAppContext reduced from ~580 to 188 lines
- `useImageApp()` public API unchanged — zero consumer diffs

## Testing
**Automated**
- [x] `bun run verify` passed (typecheck, lint, format, 206 tests, build)

Closes #107