### PR TITLE
feat: add clipboard paste upload and before/after comparison toggle

### DIFF
--- a/src/components/app/PreviewPanel.tsx
+++ b/src/components/app/PreviewPanel.tsx
@@ -1,4 +1,4 @@
-import { Show } from "solid-js";
+import { createSignal, Show } from "solid-js";
 import EmptyState from "@/components/app/preview/EmptyState";
 import ImageInfoBar from "@/components/app/preview/ImageInfoBar";
 import ErrorDisplay from "@/components/app/preview/ErrorDisplay";
@@ -6,6 +6,7 @@ import { useImageApp } from "@/components/app/state/ImageAppContext";
 
 export default function PreviewPanel() {
   const { state } = useImageApp();
+  const [showOriginal, setShowOriginal] = createSignal(false);
 
   return (
     <div class="h-full flex flex-col bg-sp-bg overflow-hidden">
@@ -23,7 +24,8 @@ export default function PreviewPanel() {
             state.processResult()?.metadata.height ?? img().metadata.height;
           const displayFileSize = () =>
             state.processResult()?.metadata.fileSize ?? img().metadata.fileSize;
-          const previewUrl = () => img().processedUrl ?? img().originalUrl;
+          const previewUrl = () =>
+            showOriginal() ? img().originalUrl : (img().processedUrl ?? img().originalUrl);
 
           return (
             <div class="flex-1 flex flex-col min-h-0">
@@ -49,6 +51,17 @@ export default function PreviewPanel() {
 
               {/* Info strip — fixed height, always present */}
               <div class="shrink-0 px-4 py-3">
+                <Show when={img().processedUrl}>
+                  <div class="flex justify-center mb-2">
+                    <button
+                      type="button"
+                      class="text-[0.75rem] font-medium px-3 py-1 rounded-sp-full border border-sp-border bg-sp-bg-card text-sp-text-muted hover:border-sp-coral hover:text-sp-coral transition-colors"
+                      onClick={() => setShowOriginal((v) => !v)}
+                    >
+                      {showOriginal() ? "Show processed" : "Compare original"}
+                    </button>
+                  </div>
+                </Show>
                 <ImageInfoBar
                   fileName={img().metadata.fileName}
                   width={displayWidth()}

--- a/src/components/app/UploadArea.tsx
+++ b/src/components/app/UploadArea.tsx
@@ -1,14 +1,28 @@
+import { onCleanup, onMount } from "solid-js";
 import UploadDropzone from "@/components/app/upload/UploadDropzone";
 import ValidationMessages from "@/components/app/upload/ValidationMessages";
 import { useImageApp } from "@/components/app/state/ImageAppContext";
 import { MAX_FILE_SIZE } from "@/config/constants";
 import { UPLOAD_ACCEPT_ATTRIBUTE } from "@/config/imageFormats";
 import { formatFileSize } from "@/utils/imageUtils";
+import { extractImageFromPaste } from "@/lib/clipboardUpload";
 
 export default function UploadArea() {
   const { state, actions } = useImageApp();
 
   let fileInputRef: HTMLInputElement | undefined;
+
+  function handlePaste(e: ClipboardEvent) {
+    const file = extractImageFromPaste(e);
+    if (file) {
+      actions.handleFileUpload(file);
+    }
+  }
+
+  onMount(() => {
+    document.addEventListener("paste", handlePaste);
+    onCleanup(() => document.removeEventListener("paste", handlePaste));
+  });
 
   function handleFileInput(e: Event) {
     const target = e.target as HTMLInputElement;

--- a/src/lib/clipboardUpload.test.ts
+++ b/src/lib/clipboardUpload.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { extractImageFromPaste } from "./clipboardUpload";
+
+function createMockClipboardEvent(items: DataTransferItem[] | null): ClipboardEvent {
+  return {
+    clipboardData: items ? ({ items } as unknown as DataTransfer) : null,
+  } as unknown as ClipboardEvent;
+}
+
+describe("extractImageFromPaste", () => {
+  it("returns the image file from a paste event with png data", () => {
+    const file = new File(["test"], "pasted-image.png", { type: "image/png" });
+    const items: DataTransferItem[] = [
+      {
+        kind: "file",
+        type: "image/png",
+        getAsFile: () => file,
+      },
+    ] as unknown as DataTransferItem[];
+
+    const event = createMockClipboardEvent(items);
+    const result = extractImageFromPaste(event);
+    expect(result).toBe(file);
+  });
+
+  it("returns null when clipboard has no files", () => {
+    const event = createMockClipboardEvent([]);
+    const result = extractImageFromPaste(event);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when clipboardData is null", () => {
+    const event = createMockClipboardEvent(null);
+    const result = extractImageFromPaste(event);
+    expect(result).toBeNull();
+  });
+
+  it("skips non-image files in clipboard", () => {
+    const file = new File(["test"], "doc.txt", { type: "text/plain" });
+    const items: DataTransferItem[] = [
+      {
+        kind: "file",
+        type: "text/plain",
+        getAsFile: () => file,
+      },
+    ] as unknown as DataTransferItem[];
+
+    const event = createMockClipboardEvent(items);
+    const result = extractImageFromPaste(event);
+    expect(result).toBeNull();
+  });
+});

--- a/src/lib/clipboardUpload.ts
+++ b/src/lib/clipboardUpload.ts
@@ -1,0 +1,13 @@
+export function extractImageFromPaste(e: ClipboardEvent): File | null {
+  const items = e.clipboardData?.items;
+  if (!items) return null;
+
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    if (item.kind === "file" && item.type.startsWith("image/")) {
+      return item.getAsFile();
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
Added two UX improvements: clipboard paste as a quick upload entry point and a before/after comparison toggle for evaluating image processing results.

## Changes
- Created `extractImageFromPaste` utility to extract image files from clipboard paste events
- Added paste event listener in UploadArea so users can paste images from clipboard
- Added before/after comparison toggle button in PreviewPanel that switches between original and processed image
- Toggle only appears when a processed result is available

## Testing
**Automated**
- [x] `bun run verify` passed (typecheck, lint, format, 207 tests, build)

Closes #81