### PR TITLE
feat: add crop support to image processing pipeline

### DIFF
--- a/src/services/cropService.test.ts
+++ b/src/services/cropService.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { validateCropRegion, cropOnCanvas } from "./cropService";
+import type { CropRegion } from "@/types/processing";
+import { setupBrowserMocks, restoreMocks } from "../test/mocks";
+
+describe("validateCropRegion", () => {
+  const imageW = 1200;
+  const imageH = 800;
+
+  it("returns null for a valid crop region", () => {
+    const region: CropRegion = { x: 100, y: 50, width: 500, height: 300 };
+    expect(validateCropRegion(region, imageW, imageH)).toBeNull();
+  });
+
+  it("rejects negative x", () => {
+    const region: CropRegion = { x: -1, y: 0, width: 100, height: 100 };
+    expect(validateCropRegion(region, imageW, imageH)).toMatch(/x must be/);
+  });
+
+  it("rejects negative y", () => {
+    const region: CropRegion = { x: 0, y: -1, width: 100, height: 100 };
+    expect(validateCropRegion(region, imageW, imageH)).toMatch(/y must be/);
+  });
+
+  it("rejects x + width exceeding image width", () => {
+    const region: CropRegion = { x: 1000, y: 0, width: 300, height: 100 };
+    expect(validateCropRegion(region, imageW, imageH)).toMatch(/width|exceeds/);
+  });
+
+  it("rejects y + height exceeding image height", () => {
+    const region: CropRegion = { x: 0, y: 700, width: 100, height: 200 };
+    expect(validateCropRegion(region, imageW, imageH)).toMatch(/height|exceeds/);
+  });
+
+  it("rejects zero width", () => {
+    const region: CropRegion = { x: 0, y: 0, width: 0, height: 100 };
+    expect(validateCropRegion(region, imageW, imageH)).toMatch(/width must be/);
+  });
+
+  it("rejects zero height", () => {
+    const region: CropRegion = { x: 0, y: 0, width: 100, height: 0 };
+    expect(validateCropRegion(region, imageW, imageH)).toMatch(/height must be/);
+  });
+});
+
+describe("cropOnCanvas", () => {
+  beforeEach(() => {
+    setupBrowserMocks();
+  });
+
+  afterEach(() => {
+    restoreMocks();
+  });
+
+  it("returns a canvas with cropped dimensions", async () => {
+    const img = new Image();
+    Object.defineProperty(img, "width", { value: 800 });
+    Object.defineProperty(img, "height", { value: 600 });
+
+    const region: CropRegion = { x: 100, y: 50, width: 200, height: 150 };
+    const canvas = cropOnCanvas(img, region);
+
+    expect(canvas.width).toBe(200);
+    expect(canvas.height).toBe(150);
+  });
+});

--- a/src/services/cropService.ts
+++ b/src/services/cropService.ts
@@ -1,0 +1,41 @@
+import type { CropRegion } from "@/types/processing";
+
+export function validateCropRegion(
+  region: CropRegion,
+  imageWidth: number,
+  imageHeight: number
+): string | null {
+  if (region.x < 0) return "x must be non-negative";
+  if (region.y < 0) return "y must be non-negative";
+  if (region.x + region.width > imageWidth) return "crop width exceeds image width";
+  if (region.y + region.height > imageHeight) return "crop height exceeds image height";
+  if (region.width <= 0) return "width must be positive";
+  if (region.height <= 0) return "height must be positive";
+  return null;
+}
+
+export function cropOnCanvas(img: HTMLImageElement, region: CropRegion): HTMLCanvasElement {
+  const canvas = document.createElement("canvas");
+  canvas.width = region.width;
+  canvas.height = region.height;
+
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("Failed to get canvas context");
+
+  ctx.imageSmoothingEnabled = true;
+  ctx.imageSmoothingQuality = "high";
+
+  ctx.drawImage(
+    img,
+    region.x,
+    region.y,
+    region.width,
+    region.height,
+    0,
+    0,
+    region.width,
+    region.height
+  );
+
+  return canvas;
+}

--- a/src/services/imageService.ts
+++ b/src/services/imageService.ts
@@ -8,6 +8,7 @@ import type {
 import { loadImage, resizeOnCanvas, canvasToBlob, getBestFormat } from "./canvasService";
 import { removeBackground } from "./backgroundRemovalService";
 import { rotateImage, flipImage } from "./transformService";
+import { cropOnCanvas, validateCropRegion } from "./cropService";
 import { decodeHeicBlob } from "./formatDetectionService";
 import { compressToTargetSize, formatSupportsQuality } from "./targetSizeService";
 import { isHeicInput } from "../config/imageFormats";
@@ -100,6 +101,16 @@ export async function processImage(
       const flipCanvas = flipImage(img, flip);
       img = await canvasToImageElement(flipCanvas);
     }
+  }
+
+  // Step 2.7: Apply crop after transforms, before resize
+  if (options.crop) {
+    const error = validateCropRegion(options.crop, img.width, img.height);
+    if (error) {
+      throw new Error(`Invalid crop region: ${error}`);
+    }
+    const cropped = cropOnCanvas(img, options.crop);
+    img = await canvasToImageElement(cropped);
   }
 
   // Step 3: Determine dimensions (resize or original)

--- a/src/types/processing.ts
+++ b/src/types/processing.ts
@@ -20,9 +20,19 @@ export interface ResizeOptions {
 export type RotationDeg = 90 | 180 | 270;
 
 /**
- * Axis along which to mirror the image.
+ * Flip axis along which to mirror the image.
  */
 export type FlipAxis = "horizontal" | "vertical";
+
+/**
+ * Crop region in source-image pixel coordinates.
+ */
+export interface CropRegion {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
 
 /**
  * Transform options applied before resize/format operations.
@@ -51,11 +61,12 @@ export interface ImageAdjustments {
 export interface ProcessOptions {
   resize?: ResizeOptions;
   format?: ImageFormat;
-  quality?: number; // 0-1 range for compression quality
+  quality?: number;
   removeBackground?: boolean;
   transform?: TransformOptions;
-  targetFileSize?: number; // target output size in bytes
+  targetFileSize?: number;
   adjustments?: ImageAdjustments;
+  crop?: CropRegion;
 }
 
 /**


### PR DESCRIPTION
## Summary
Added crop support to the image processing pipeline with validation and canvas-based cropping. Crop is applied after transforms (rotate/flip) and before resize, ensuring correct composition order.

## Changes
- Added `CropRegion` type to processing types (x, y, width, height in pixel coordinates)
- Added `validateCropRegion` for bounds checking against source image dimensions
- Added `cropOnCanvas` for applying crop to HTMLImageElement via canvas
- Integrated crop step into `processImage` pipeline after transforms and before resize
- Added `crop` option to `ProcessOptions`
- Tests cover all validation errors and canvas output dimensions

## Testing
**Automated**
- [x] `bun run verify` passed (typecheck, lint, format, 211 tests, build)

Closes #75