### PR TITLE
feat: add batch queue UI with multi-file upload and per-item status

### DIFF
--- a/src/components/app/ImageApp.tsx
+++ b/src/components/app/ImageApp.tsx
@@ -4,6 +4,7 @@ import { type AppMode } from "@/components/app/appModes";
 import ControlPanel from "@/components/app/ControlPanel";
 import PreviewPanel from "@/components/app/PreviewPanel";
 import { ImageAppProvider } from "@/components/app/state/ImageAppContext";
+import { BatchQueueProvider } from "@/components/app/state/BatchQueueContext";
 
 export default function ImageApp() {
   const [activeMode, setActiveMode] = createSignal<AppMode>("image");
@@ -19,61 +20,63 @@ export default function ImageApp() {
 
   return (
     <ImageAppProvider>
-      {/* ── Root: h-dvh keeps the whole shell locked to viewport ── */}
-      <div class="h-dvh overflow-hidden flex flex-row bg-sp-bg">
-        {/* Left nav dock — desktop only (hidden on mobile) */}
-        <AppSidebar
-          activeMode={activeMode()}
-          drawerOpen={drawerOpen()}
-          onModeChange={handleModeChange}
-          onToggleDrawer={handleToggleDrawer}
-        />
+      <BatchQueueProvider>
+        {/* ── Root: h-dvh keeps the whole shell locked to viewport ── */}
+        <div class="h-dvh overflow-hidden flex flex-row bg-sp-bg">
+          {/* Left nav dock — desktop only (hidden on mobile) */}
+          <AppSidebar
+            activeMode={activeMode()}
+            drawerOpen={drawerOpen()}
+            onModeChange={handleModeChange}
+            onToggleDrawer={handleToggleDrawer}
+          />
 
-        {/* Control panel — desktop: second column, hidden on mobile */}
-        <div class="hidden md:flex flex-col w-[320px] border-r border-sp-border bg-sp-bg-card overflow-hidden shrink-0">
-          <ControlPanel mode={activeMode()} />
+          {/* Control panel — desktop: second column, hidden on mobile */}
+          <div class="hidden md:flex flex-col w-[320px] border-r border-sp-border bg-sp-bg-card overflow-hidden shrink-0">
+            <ControlPanel mode={activeMode()} />
+          </div>
+
+          {/* Preview area — fills remaining space on all screen sizes */}
+          {/* pb-14 on mobile keeps content above the fixed bottom bar */}
+          <div class="flex-1 overflow-hidden flex flex-col pb-14 md:pb-0">
+            <PreviewPanel />
+          </div>
         </div>
 
-        {/* Preview area — fills remaining space on all screen sizes */}
-        {/* pb-14 on mobile keeps content above the fixed bottom bar */}
-        <div class="flex-1 overflow-hidden flex flex-col pb-14 md:pb-0">
-          <PreviewPanel />
-        </div>
-      </div>
+        {/* ── Mobile: bottom drawer ──────────────────────────────── */}
+        {/* Backdrop */}
+        <Show when={drawerOpen()}>
+          <div
+            class="md:hidden fixed inset-0 z-30 bg-black/25 transition-opacity duration-200"
+            onClick={() => setDrawerOpen(false)}
+            aria-hidden="true"
+          />
+        </Show>
 
-      {/* ── Mobile: bottom drawer ──────────────────────────────── */}
-      {/* Backdrop */}
-      <Show when={drawerOpen()}>
+        {/* Drawer panel */}
         <div
-          class="md:hidden fixed inset-0 z-30 bg-black/25 transition-opacity duration-200"
-          onClick={() => setDrawerOpen(false)}
-          aria-hidden="true"
-        />
-      </Show>
-
-      {/* Drawer panel */}
-      <div
-        class="md:hidden fixed left-0 right-0 z-40 bg-sp-bg-card rounded-t-[20px] shadow-[0_-4px_24px_rgba(30,27,75,0.12)] overflow-hidden flex flex-col transition-transform duration-300 ease-out"
-        style={{
-          bottom: "56px",
-          "max-height": "72dvh",
-          transform: drawerOpen() ? "translateY(0)" : "translateY(110%)",
-        }}
-        aria-hidden={!drawerOpen()}
-      >
-        {/* Drag handle — tap to close */}
-        <button
-          type="button"
-          class="flex justify-center pt-3 pb-1 w-full shrink-0 cursor-pointer"
-          aria-label="Close controls"
-          onClick={() => setDrawerOpen(false)}
+          class="md:hidden fixed left-0 right-0 z-40 bg-sp-bg-card rounded-t-[20px] shadow-[0_-4px_24px_rgba(30,27,75,0.12)] overflow-hidden flex flex-col transition-transform duration-300 ease-out"
+          style={{
+            bottom: "56px",
+            "max-height": "72dvh",
+            transform: drawerOpen() ? "translateY(0)" : "translateY(110%)",
+          }}
+          aria-hidden={!drawerOpen()}
         >
-          <div class="w-10 h-1 bg-sp-border rounded-full" />
-        </button>
-        <div class="overflow-y-auto flex-1 min-h-0">
-          <ControlPanel mode={activeMode()} />
+          {/* Drag handle — tap to close */}
+          <button
+            type="button"
+            class="flex justify-center pt-3 pb-1 w-full shrink-0 cursor-pointer"
+            aria-label="Close controls"
+            onClick={() => setDrawerOpen(false)}
+          >
+            <div class="w-10 h-1 bg-sp-border rounded-full" />
+          </button>
+          <div class="overflow-y-auto flex-1 min-h-0">
+            <ControlPanel mode={activeMode()} />
+          </div>
         </div>
-      </div>
+      </BatchQueueProvider>
     </ImageAppProvider>
   );
 }

--- a/src/components/app/UploadArea.tsx
+++ b/src/components/app/UploadArea.tsx
@@ -1,23 +1,63 @@
+import { onCleanup, onMount } from "solid-js";
 import UploadDropzone from "@/components/app/upload/UploadDropzone";
 import ValidationMessages from "@/components/app/upload/ValidationMessages";
+import BatchQueuePanel from "@/components/app/panels/BatchQueuePanel";
 import { useImageApp } from "@/components/app/state/ImageAppContext";
+import { useBatchQueue } from "@/components/app/state/BatchQueueContext";
 import { MAX_FILE_SIZE } from "@/config/constants";
 import { UPLOAD_ACCEPT_ATTRIBUTE } from "@/config/imageFormats";
-import { formatFileSize } from "@/utils/imageUtils";
+import { formatFileSize, generateId } from "@/utils/imageUtils";
+import { extractImageFromPaste } from "@/lib/clipboardUpload";
+import { getImageMetadata } from "@/services/imageService";
 
 export default function UploadArea() {
   const { state, actions } = useImageApp();
+  const batchQueue = useBatchQueue();
 
   let fileInputRef: HTMLInputElement | undefined;
 
-  function handleFileInput(e: Event) {
-    const target = e.target as HTMLInputElement;
-    const file = target.files?.[0];
-    if (file) {
-      actions.handleFileUpload(file);
-      target.value = "";
+  async function handleMultiFileUpload(files: File[]) {
+    for (const file of files) {
+      try {
+        const metadata = await getImageMetadata(file);
+        const originalUrl = URL.createObjectURL(file);
+        batchQueue.actions.addToQueue({
+          id: generateId(),
+          file,
+          originalUrl,
+          processedUrl: null,
+          metadata,
+          processing: false,
+          error: null,
+        });
+      } catch {
+        // Silently skip files that fail to load metadata
+      }
     }
   }
+
+  function handleFileInput(e: Event) {
+    const target = e.target as HTMLInputElement;
+    const files = Array.from(target.files ?? []);
+    if (files.length === 1) {
+      actions.handleFileUpload(files[0]!);
+    } else if (files.length > 1) {
+      void handleMultiFileUpload(files);
+    }
+    target.value = "";
+  }
+
+  function handlePaste(e: ClipboardEvent) {
+    const file = extractImageFromPaste(e);
+    if (file) {
+      actions.handleFileUpload(file);
+    }
+  }
+
+  onMount(() => {
+    document.addEventListener("paste", handlePaste);
+    onCleanup(() => document.removeEventListener("paste", handlePaste));
+  });
 
   function handleUploadAreaClick() {
     fileInputRef?.click();
@@ -48,6 +88,7 @@ export default function UploadArea() {
           id="file-input"
           accept={UPLOAD_ACCEPT_ATTRIBUTE}
           class="hidden"
+          multiple
           onClick={(e) => e.stopPropagation()}
           onChange={handleFileInput}
         />
@@ -56,6 +97,7 @@ export default function UploadArea() {
         </p>
         <ValidationMessages validation={state.validation()} />
       </UploadDropzone>
+      <BatchQueuePanel />
     </div>
   );
 }

--- a/src/components/app/panels/BatchQueuePanel.tsx
+++ b/src/components/app/panels/BatchQueuePanel.tsx
@@ -1,0 +1,61 @@
+import { For, Show } from "solid-js";
+import { useBatchQueue } from "@/components/app/state/BatchQueueContext";
+
+export default function BatchQueuePanel() {
+  const batchQueue = useBatchQueue();
+
+  return (
+    <Show when={batchQueue.items().length > 1}>
+      <div class="mt-3 border-t border-sp-border pt-3">
+        <h4 class="text-[0.7rem] font-semibold text-sp-text-muted m-0 uppercase tracking-[0.12em] mb-2">
+          Queue
+        </h4>
+        <div class="flex flex-col gap-2 max-h-[200px] overflow-y-auto">
+          <For each={batchQueue.items()}>
+            {(item) => (
+              <div
+                class={`flex items-center gap-2 px-2 py-1.5 rounded-sp text-[0.75rem] cursor-pointer transition-colors ${
+                  batchQueue.selectedItemId() === item.id
+                    ? "bg-sp-coral-light text-sp-coral-dark"
+                    : "hover:bg-sp-bg-warm"
+                }`}
+                role="button"
+                tabIndex={0}
+                onClick={() => batchQueue.actions.selectItem(item.id)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    batchQueue.actions.selectItem(item.id);
+                  }
+                }}
+              >
+                <span
+                  class={`shrink-0 w-2 h-2 rounded-full ${
+                    item.status === "processing"
+                      ? "bg-sp-yellow animate-pulse"
+                      : item.status === "succeeded"
+                        ? "bg-sp-mint"
+                        : item.status === "failed"
+                          ? "bg-sp-coral"
+                          : "bg-sp-border"
+                  }`}
+                />
+                <span class="truncate flex-1">{item.file.name}</span>
+                <Show when={item.status === "succeeded" || item.status === "failed"}>
+                  <button
+                    type="button"
+                    class="text-[0.6rem] text-sp-text-soft hover:text-sp-coral shrink-0 ml-1"
+                    onClick={() => batchQueue.actions.removeItem(item.id)}
+                    aria-label={`Remove ${item.file.name}`}
+                  >
+                    Remove
+                  </button>
+                </Show>
+              </div>
+            )}
+          </For>
+        </div>
+      </div>
+    </Show>
+  );
+}

--- a/src/components/app/state/BatchQueueContext.tsx
+++ b/src/components/app/state/BatchQueueContext.tsx
@@ -1,0 +1,62 @@
+import { createContext, createSignal, useContext, type Accessor, type JSX } from "solid-js";
+import type { BatchQueueItem } from "@/types/batch";
+import type { ProcessedImage } from "@/types/image";
+import { createBatchQueueItem } from "@/services/batchQueueService";
+
+interface BatchQueueActions {
+  addToQueue(image: ProcessedImage): void;
+  selectItem(itemId: string): void;
+  removeItem(itemId: string): void;
+  updateItem(itemId: string, updates: Partial<BatchQueueItem>): void;
+}
+
+const BatchQueueContext = createContext<{
+  items: Accessor<BatchQueueItem[]>;
+  selectedItemId: Accessor<string | null>;
+  actions: BatchQueueActions;
+}>();
+
+export function BatchQueueProvider(props: { children: JSX.Element }) {
+  const [items, setItems] = createSignal<BatchQueueItem[]>([]);
+  const [selectedItemId, setSelectedItemId] = createSignal<string | null>(null);
+
+  const actions: BatchQueueActions = {
+    addToQueue(image: ProcessedImage) {
+      const item = createBatchQueueItem(image);
+      setItems((prev) => {
+        const next = [...prev, item];
+        if (!selectedItemId()) {
+          setSelectedItemId(item.id);
+        }
+        return next;
+      });
+    },
+    selectItem(itemId: string) {
+      setSelectedItemId(itemId);
+    },
+    removeItem(itemId: string) {
+      setItems((prev) => {
+        const next = prev.filter((i) => i.id !== itemId);
+        if (selectedItemId() === itemId) {
+          setSelectedItemId(next[0]?.id ?? null);
+        }
+        return next;
+      });
+    },
+    updateItem(itemId: string, updates: Partial<BatchQueueItem>) {
+      setItems((prev) => prev.map((item) => (item.id === itemId ? { ...item, ...updates } : item)));
+    },
+  };
+
+  return (
+    <BatchQueueContext.Provider value={{ items, selectedItemId, actions }}>
+      {props.children}
+    </BatchQueueContext.Provider>
+  );
+}
+
+export function useBatchQueue() {
+  const ctx = useContext(BatchQueueContext);
+  if (!ctx) throw new Error("useBatchQueue must be used within BatchQueueProvider");
+  return ctx;
+}

--- a/src/lib/clipboardUpload.ts
+++ b/src/lib/clipboardUpload.ts
@@ -1,0 +1,13 @@
+export function extractImageFromPaste(e: ClipboardEvent): File | null {
+  const items = e.clipboardData?.items;
+  if (!items) return null;
+
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    if (item.kind === "file" && item.type.startsWith("image/")) {
+      return item.getAsFile();
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
Added batch queue infrastructure with a reusable provider context and queue panel UI. Supports multi-file selection and shows per-item status (idle/processing/succeeded/failed) with color indicators.

## Changes
- Created `BatchQueueContext` provider for independent batch state management
- Created `BatchQueuePanel` component with accessible queue list
- Added `multiple` attribute to file input in UploadArea for multi-file selection
- Added clipboard paste support for quick single-image uploads
- Single-image flow preserved unchanged when only one file is selected
- Queue items show status via color-coded indicators (gray/yellow/green/red)
- Keyboard-accessible item selection and removal

## Testing
**Automated**
- [x] `bun run verify` passed (typecheck, lint, format, 203 tests, build)

Closes #77