### PR TITLE
feat: add dedicated AVIF encoder path with explicit quality control

### DIFF
--- a/src/config/imageFormats.test.ts
+++ b/src/config/imageFormats.test.ts
@@ -68,6 +68,6 @@ describe("imageFormats", () => {
       "image/webp",
       "image/avif",
     ]);
-    expect(QUALITY_CONTROLLED_OUTPUT_FORMATS).toEqual(["image/jpeg", "image/webp"]);
+    expect(QUALITY_CONTROLLED_OUTPUT_FORMATS).toEqual(["image/jpeg", "image/webp", "image/avif"]);
   });
 });

--- a/src/config/imageFormats.ts
+++ b/src/config/imageFormats.ts
@@ -1,7 +1,10 @@
 import type { ImageFormat } from "../types/image";
 
 export type ConvertibleImageFormat = Exclude<ImageFormat, "image/heic" | "image/heif">;
-export type QualityControlledImageFormat = Extract<ImageFormat, "image/jpeg" | "image/webp">;
+export type QualityControlledImageFormat = Extract<
+  ImageFormat,
+  "image/jpeg" | "image/webp" | "image/avif"
+>;
 
 export const ACCEPTED_INPUT_FORMATS: readonly ImageFormat[] = [
   "image/jpeg",
@@ -22,6 +25,7 @@ export const CONVERTIBLE_OUTPUT_FORMATS: readonly ConvertibleImageFormat[] = [
 export const QUALITY_CONTROLLED_OUTPUT_FORMATS: readonly QualityControlledImageFormat[] = [
   "image/jpeg",
   "image/webp",
+  "image/avif",
 ];
 
 export const IMAGE_FORMAT_LABELS: Record<ImageFormat, string> = {

--- a/src/services/avifEncoderService.test.ts
+++ b/src/services/avifEncoderService.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { mapAvifQuality } from "./avifEncoderService";
+
+describe("mapAvifQuality", () => {
+  it("maps 1-100 quality to avif quantization range", () => {
+    expect(mapAvifQuality(100)).toBeLessThanOrEqual(20);
+    expect(mapAvifQuality(1)).toBeGreaterThanOrEqual(60);
+  });
+
+  it("returns higher values for lower quality input", () => {
+    const high = mapAvifQuality(90);
+    const low = mapAvifQuality(10);
+    expect(high).toBeLessThan(low);
+  });
+
+  it("clamps to valid range", () => {
+    expect(mapAvifQuality(200)).toBeGreaterThan(0);
+    expect(mapAvifQuality(0)).toBeGreaterThan(0);
+    expect(mapAvifQuality(-1)).toBeGreaterThan(0);
+  });
+});

--- a/src/services/avifEncoderService.ts
+++ b/src/services/avifEncoderService.ts
@@ -1,0 +1,35 @@
+/**
+ * AVIF encoder service with explicit quality and effort control.
+ *
+ * Currently delegates to the browser's canvas.toBlob('image/avif') with
+ * quality mapping. A dedicated WebAssembly encoder can be swapped in
+ * without changing the public API.
+ */
+
+/**
+ * Map a 1-100 quality value to an AVIF quantization parameter.
+ * Lower quantization = higher quality. AVIF encoders typically use
+ * a range of 0 (lossless) to 63 (worst).
+ */
+export function mapAvifQuality(quality: number): number {
+  const clamped = Math.max(1, Math.min(100, quality));
+  return Math.round(20 + ((100 - clamped) / 100) * 43);
+}
+
+export async function encodeAvif(canvas: HTMLCanvasElement, quality: number): Promise<Blob> {
+  const avifQuality = mapAvifQuality(quality);
+
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        if (blob) {
+          resolve(blob);
+        } else {
+          reject(new Error("Failed to encode AVIF"));
+        }
+      },
+      "image/avif",
+      avifQuality / 100
+    );
+  });
+}

--- a/src/services/imageService.ts
+++ b/src/services/imageService.ts
@@ -12,6 +12,7 @@ import { decodeHeicBlob } from "./formatDetectionService";
 import { compressToTargetSize, formatSupportsQuality } from "./targetSizeService";
 import { isHeicInput } from "../config/imageFormats";
 import { buildFilterString, isNoOpAdjustments } from "./adjustmentService";
+import { encodeAvif } from "./avifEncoderService";
 
 /**
  * Calculate dimensions maintaining aspect ratio
@@ -137,16 +138,17 @@ export async function processImage(
   format = getBestFormat(format);
 
   // Step 6: Determine quality (compress or default)
-  // Browser-native quality control only applies to the formats we explicitly support.
   let quality: number | undefined;
-  if (format === "image/jpeg" || format === "image/webp") {
+  if (format === "image/jpeg" || format === "image/webp" || format === "image/avif") {
     quality = options.quality !== undefined ? options.quality : 0.92;
   }
 
   // Step 7: Convert to blob
   let blob: Blob;
 
-  if (options.targetFileSize && formatSupportsQuality(format)) {
+  if (format === "image/avif" && quality !== undefined) {
+    blob = await encodeAvif(canvas, Math.round(quality * 100));
+  } else if (options.targetFileSize && formatSupportsQuality(format)) {
     const sizeResult = await compressToTargetSize(
       { canvas, format, targetBytes: options.targetFileSize },
       canvasToBlob

--- a/src/services/targetSizeService.test.ts
+++ b/src/services/targetSizeService.test.ts
@@ -9,7 +9,7 @@ describe("targetSizeService", () => {
       { format: "image/jpeg", expected: true },
       { format: "image/webp", expected: true },
       { format: "image/png", expected: false },
-      { format: "image/avif", expected: false },
+      { format: "image/avif", expected: true },
     ])("returns $expected for $format", ({ format, expected }) => {
       expect(formatSupportsQuality(format)).toBe(expected);
     });


### PR DESCRIPTION
## Summary
Added a dedicated AVIF encoder path with quality-to-quantization mapping, giving the app explicit control over AVIF encoding quality. AVIF is now part of the quality-controlled output formats, enabling the quality slider for AVIF exports.

## Changes
- Created `avifEncoderService` with `mapAvifQuality` for quality-to-quantization mapping
- Added `encodeAvif` function using browser canvas.toBlob with mapped quality
- Added AVIF to quality-controlled output formats list
- Integrated AVIF encoder into image processing pipeline
- Updated tests to reflect AVIF quality control support

## Testing
**Automated**
- [x] `bun run verify` passed (typecheck, lint, format, 206 tests, build)

Closes #101