### PR TITLE
test: remove stale changelog route coverage

### DIFF
--- a/e2e/marketing-pages.spec.ts
+++ b/e2e/marketing-pages.spec.ts
@@ -1,12 +1,11 @@
 import { test, expect } from "@playwright/test";
 
-const ROUTES: { path: string; title: RegExp; navPath?: string }[] = [
+const ROUTES: { path: string; title: RegExp }[] = [
   { path: "/", title: /Your images deserve/i },
-  { path: "/features", title: /Everything you need/i, navPath: "/features" },
-  { path: "/about", title: /Built for privacy/i, navPath: "/about" },
-  { path: "/faq", title: /Frequently asked questions/i, navPath: "/faq" },
-  { path: "/privacy", title: /Your images never leave/i, navPath: "/privacy" },
-  { path: "/changelog", title: /What.s new in Reshrimp/i, navPath: "/changelog" },
+  { path: "/features", title: /Everything you need/i },
+  { path: "/about", title: /Built for privacy/i },
+  { path: "/faq", title: /Frequently asked questions/i },
+  { path: "/privacy", title: /Your images never leave/i },
   { path: "/404", title: /Page not found/i },
 ];
 


### PR DESCRIPTION
## Summary
Removes stale marketing E2E coverage for a `/changelog` page that no longer exists. This keeps the test suite aligned with the actual published route surface and trims an unused field from the route table in the same file.

## Changes
- remove the stale `/changelog` case from `e2e/marketing-pages.spec.ts`
- drop the unused `navPath` field from the route table type and entries

## Testing
**Automated**
- [x] `bun run test` passed (153 tests)
- [x] `bun run verify` passed

## Notes
This is a deletion-only cleanup. If CI passes, it can be merged directly.