### PR TITLE
chore: remove unused react types

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,6 @@
         "@tailwindcss/vite": "^4.2.4",
         "@testing-library/jest-dom": "^6.9.1",
         "@types/eslint-plugin-jsx-a11y": "^6.10.1",
-        "@types/react": "^19.2.14",
         "@typescript-eslint/eslint-plugin": "^8.59.1",
         "@typescript-eslint/parser": "^8.59.1",
         "@vite-pwa/astro": "^1.2.0",
@@ -686,8 +685,6 @@
     "@types/nlcst": ["@types/nlcst@2.0.3", "", { "dependencies": { "@types/unist": "*" } }, "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA=="],
 
     "@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
-
-    "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "@types/resolve": ["@types/resolve@1.20.2", "", {}, "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q=="],
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "@tailwindcss/vite": "^4.2.4",
     "@testing-library/jest-dom": "^6.9.1",
     "@types/eslint-plugin-jsx-a11y": "^6.10.1",
-    "@types/react": "^19.2.14",
     "@typescript-eslint/eslint-plugin": "^8.59.1",
     "@typescript-eslint/parser": "^8.59.1",
     "@vite-pwa/astro": "^1.2.0",


### PR DESCRIPTION
## Summary
Removes the unused `@types/react` development dependency. The repository does not import React, uses Solid for JSX typing, and passes the full quality gate without the package.

## Changes
- remove `@types/react` from `package.json`
- update `bun.lock`

## Testing
**Automated**
- [x] `bun run test` passed (153 tests)
- [x] `bun run verify` passed

## Notes
This is a deletion-only dependency cleanup. If CI passes, it can be merged directly.