### PR TITLE
chore: remove unused validation helpers

### DIFF
--- a/src/services/validationService.test.ts
+++ b/src/services/validationService.test.ts
@@ -1,11 +1,5 @@
 import { describe, it, expect } from "vitest";
-import {
-  getSupportedFormats,
-  isSupportedFormat,
-  validateImageFile,
-  getFileExtension,
-  generateDownloadFilename,
-} from "./validationService";
+import { validateImageFile, getFileExtension, generateDownloadFilename } from "./validationService";
 import type { ImageFormat } from "../types/image";
 
 /**
@@ -19,47 +13,6 @@ function makeFile(name: string, type: string, sizeBytes: number): File {
 }
 
 const MB = 1024 * 1024;
-
-describe("getSupportedFormats", () => {
-  it("returns all accepted input formats", () => {
-    expect(getSupportedFormats()).toHaveLength(6);
-  });
-
-  it("contains the expected formats", () => {
-    expect(getSupportedFormats()).toEqual(
-      expect.arrayContaining(["image/jpeg", "image/png", "image/webp"])
-    );
-  });
-
-  it("returns a new array each call (not mutated between calls)", () => {
-    const a = getSupportedFormats();
-    const b = getSupportedFormats();
-    expect(a).not.toBe(b);
-  });
-});
-
-describe("isSupportedFormat", () => {
-  it("returns true for supported formats", () => {
-    expect(isSupportedFormat("image/jpeg")).toBe(true);
-    expect(isSupportedFormat("image/png")).toBe(true);
-    expect(isSupportedFormat("image/webp")).toBe(true);
-    expect(isSupportedFormat("image/gif")).toBe(false);
-  });
-
-  it("returns false for unsupported formats", () => {
-    expect(isSupportedFormat("image/bmp")).toBe(false);
-    expect(isSupportedFormat("application/pdf")).toBe(false);
-  });
-
-  it("returns false for empty string", () => {
-    expect(isSupportedFormat("")).toBe(false);
-  });
-
-  it("is case-sensitive — rejects mixed-case MIME types", () => {
-    expect(isSupportedFormat("image/JPEG")).toBe(false);
-    expect(isSupportedFormat("Image/jpeg")).toBe(false);
-  });
-});
 
 describe("validateImageFile", () => {
   it("returns error when file is null/falsy", () => {

--- a/src/services/validationService.ts
+++ b/src/services/validationService.ts
@@ -1,25 +1,7 @@
-import {
-  ACCEPTED_INPUT_FORMATS,
-  getSupportedImageFormatSummary,
-  isAcceptedInputFormat,
-} from "../config/imageFormats";
+import { getSupportedImageFormatSummary, isAcceptedInputFormat } from "../config/imageFormats";
 import { MAX_FILE_SIZE, RECOMMENDED_MAX_SIZE } from "../config/constants";
 import type { ImageFormat, ValidationResult } from "../types/image";
 import { formatFileSize } from "../utils/imageUtils";
-
-/**
- * Get list of supported image formats
- */
-export function getSupportedFormats(): ImageFormat[] {
-  return [...ACCEPTED_INPUT_FORMATS];
-}
-
-/**
- * Check if a MIME type is a supported image format
- */
-export function isSupportedFormat(mimeType: string): boolean {
-  return ACCEPTED_INPUT_FORMATS.includes(mimeType as ImageFormat);
-}
 
 /**
  * Validate an image file for processing


### PR DESCRIPTION
## Summary
Removes two unused validation helper exports and the tests that only existed for them. The active app uses `validateImageFile()` and format config helpers directly, so keeping these extra exports only widened the service surface without serving the product.

## Changes
- remove `getSupportedFormats()` from `validationService`
- remove `isSupportedFormat()` from `validationService`
- delete the test coverage that only exercised those helpers

## Testing
**Automated**
- [x] `bun run test` passed (146 tests)
- [x] `bun run verify` passed

## Notes
This is a deletion-only cleanup. If CI passes, it can be merged directly.