### PR TITLE
chore: remove unused avif probe

### DIFF
--- a/src/services/formatDetectionService.test.ts
+++ b/src/services/formatDetectionService.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   ACCEPTED_INPUT_FORMATS,
@@ -7,7 +7,7 @@ import {
   isConvertibleOutputFormat,
   isHeicInput,
 } from "../config/imageFormats";
-import { decodeHeicBlob, detectAvifSupport } from "./formatDetectionService";
+import { decodeHeicBlob } from "./formatDetectionService";
 
 describe("formatDetectionService", () => {
   afterEach(() => {
@@ -42,40 +42,6 @@ describe("formatDetectionService", () => {
       expect(
         isConvertibleOutputFormat(format as Parameters<typeof isConvertibleOutputFormat>[0])
       ).toBe(expected);
-    });
-  });
-
-  describe("detectAvifSupport", () => {
-    let origToBlob: typeof HTMLCanvasElement.prototype.toBlob;
-
-    beforeEach(() => {
-      origToBlob = HTMLCanvasElement.prototype.toBlob;
-    });
-
-    afterEach(() => {
-      HTMLCanvasElement.prototype.toBlob = origToBlob;
-    });
-
-    it("returns true when the browser can encode AVIF", async () => {
-      HTMLCanvasElement.prototype.toBlob = vi.fn((callback, type) => {
-        if (type === "image/avif") {
-          callback!(new Blob([], { type: "image/avif" }));
-        }
-        return undefined as unknown as void;
-      });
-
-      await expect(detectAvifSupport()).resolves.toBe(true);
-    });
-
-    it("returns false when the browser cannot encode AVIF", async () => {
-      HTMLCanvasElement.prototype.toBlob = vi.fn((callback, type) => {
-        if (type === "image/avif") {
-          callback!(null as unknown as Blob);
-        }
-        return undefined as unknown as void;
-      });
-
-      await expect(detectAvifSupport()).resolves.toBe(false);
     });
   });
 

--- a/src/services/formatDetectionService.ts
+++ b/src/services/formatDetectionService.ts
@@ -57,30 +57,6 @@ function loadHeic2AnyConverter(): Promise<Heic2AnyConverter> {
 }
 
 /**
- * Detect whether the browser can encode AVIF output.
- *
- * Uses a small canvas + toBlob probe. Result should be cached by the caller.
- */
-export function detectAvifSupport(): Promise<boolean> {
-  return new Promise((resolve) => {
-    try {
-      const canvas = document.createElement("canvas");
-      canvas.width = 1;
-      canvas.height = 1;
-      canvas.toBlob(
-        (blob) => {
-          resolve(blob !== null && blob.type === "image/avif");
-        },
-        "image/avif",
-        0.5
-      );
-    } catch {
-      resolve(false);
-    }
-  });
-}
-
-/**
  * Decode a HEIC/HEIF blob into a PNG blob using the heic2any library.
  *
  * The conversion happens entirely in-browser; no data leaves the device.


### PR DESCRIPTION
## Summary
Removes the unused AVIF capability probe from `formatDetectionService`. Nothing in the current app uses this helper at runtime, so keeping it only added dead code and isolated test coverage.

## Changes
- remove `detectAvifSupport()` from `formatDetectionService`
- remove the tests that only exercised that helper

## Testing
**Automated**
- [x] `bun run test` passed (144 tests)
- [x] `bun run verify` passed

## Notes
This is a deletion-only cleanup. If CI passes, it can be merged directly.