### PR TITLE
chore: remove unused app session state fields

### DIFF
--- a/src/components/app/state/ImageAppContext.tsx
+++ b/src/components/app/state/ImageAppContext.tsx
@@ -29,7 +29,7 @@ import {
   rebaseDimensionValues,
 } from "@/services/imageWorkflowService";
 import { validateImageFile, generateDownloadFilename } from "@/services/validationService";
-import { formatFileSize, generateId, convertFromPx } from "@/utils/imageUtils";
+import { formatFileSize, convertFromPx } from "@/utils/imageUtils";
 import { DEFAULT_DPI } from "@/config/constants";
 import { getInitialOutputFormat, supportsBrowserQualityControl } from "@/config/imageFormats";
 
@@ -312,13 +312,10 @@ export function ImageAppProvider(props: { children: JSX.Element }) {
       const originalUrl = URL.createObjectURL(file);
 
       const processedImage: ProcessedImage = {
-        id: generateId(),
         file,
         originalUrl,
         processedUrl: null,
         metadata,
-        processing: false,
-        error: null,
       };
 
       // Batch all state resets into a single DOM update to prevent flickering.

--- a/src/types/image.ts
+++ b/src/types/image.ts
@@ -24,13 +24,10 @@ export interface ImageMetadata {
  * Represents the active image session with original and processed states.
  */
 export interface ProcessedImage {
-  id: string;
   file: File;
   originalUrl: string;
   processedUrl: string | null;
   metadata: ImageMetadata;
-  processing: boolean;
-  error: string | null;
 }
 
 /**

--- a/src/utils/imageUtils.test.ts
+++ b/src/utils/imageUtils.test.ts
@@ -5,7 +5,6 @@ import {
   formatFileSize,
   calculateHeightFromWidth,
   calculateWidthFromHeight,
-  generateId,
   convertToPx,
   convertFromPx,
 } from "./imageUtils";
@@ -120,19 +119,6 @@ describe("calculateWidthFromHeight", () => {
   it("rounds non-integer results", () => {
     // 3:2 aspect → height 10 → width = 10 * 1.5 = 15
     expect(calculateWidthFromHeight(3, 2, 10)).toBe(15);
-  });
-});
-
-describe("generateId", () => {
-  it("returns a non-empty string", () => {
-    const id = generateId();
-    expect(typeof id).toBe("string");
-    expect(id.length).toBeGreaterThan(0);
-  });
-
-  it("returns unique values across calls", () => {
-    const ids = new Set(Array.from({ length: 20 }, () => generateId()));
-    expect(ids.size).toBe(20);
   });
 });
 

--- a/src/utils/imageUtils.ts
+++ b/src/utils/imageUtils.ts
@@ -112,10 +112,3 @@ export function convertFromPx(
       return dpi === 0 ? 0 : (px * 2.54) / dpi;
   }
 }
-
-/**
- * Generate a unique ID
- */
-export function generateId(): string {
-  return `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
-}


### PR DESCRIPTION
## Summary
Removes unused fields (`id`, `generateId`, `processing`, `error`) from the `ProcessedImage` interface and related code that became dead after the single-image session refactor.

## Changes
- Removed `id`, `processing`, and `error` fields from the `ProcessedImage` type
- Removed the `generateId` utility function and its test suite
- Removed `generateId` usage from `ImageAppProvider`

## Testing
**Automated**
- [x] `bun run verify` passed (142 tests, lint, format check, build)