### PR TITLE
refactor: remove control panel wrapper

### DIFF
--- a/src/components/app/ControlPanel.tsx
+++ b/src/components/app/ControlPanel.tsx
@@ -1,9 +1,0 @@
-import ProcessPanel from "@/components/app/panels/ProcessPanel";
-
-export default function ControlPanel() {
-  return (
-    <div class="flex flex-col flex-1 overflow-hidden min-h-0">
-      <ProcessPanel />
-    </div>
-  );
-}

--- a/src/components/app/ImageApp.tsx
+++ b/src/components/app/ImageApp.tsx
@@ -1,6 +1,6 @@
 import { createSignal, Show } from "solid-js";
 import AppSidebar from "@/components/app/AppSidebar";
-import ControlPanel from "@/components/app/ControlPanel";
+import ProcessPanel from "@/components/app/panels/ProcessPanel";
 import PreviewPanel from "@/components/app/PreviewPanel";
 import { ImageAppProvider } from "@/components/app/state/ImageAppContext";
 
@@ -20,7 +20,9 @@ export default function ImageApp() {
 
         {/* Control panel — desktop: second column, hidden on mobile */}
         <div class="hidden md:flex flex-col w-[320px] border-r border-sp-border bg-sp-bg-card overflow-hidden shrink-0">
-          <ControlPanel />
+          <div class="flex flex-col flex-1 overflow-hidden min-h-0">
+            <ProcessPanel />
+          </div>
         </div>
 
         {/* Preview area — fills remaining space on all screen sizes */}
@@ -62,7 +64,9 @@ export default function ImageApp() {
           <div class="w-10 h-1 bg-sp-border rounded-full" />
         </button>
         <div class="overflow-y-auto flex-1 min-h-0">
-          <ControlPanel />
+          <div class="flex flex-col flex-1 overflow-hidden min-h-0">
+            <ProcessPanel />
+          </div>
         </div>
       </div>
     </ImageAppProvider>


### PR DESCRIPTION
## Summary
Removes the residual `ControlPanel` pass-through wrapper from the app shell. `ImageApp` now renders `ProcessPanel` directly in both the desktop rail and mobile drawer, which trims one unnecessary layer without changing behavior.

## Changes
- delete `src/components/app/ControlPanel.tsx`
- render `ProcessPanel` directly from `ImageApp`
- keep the existing desktop and mobile panel container structure intact

## Testing
**Automated**
- [x] `bun run test` passed (142 tests)
- [x] `bun run verify` passed

## Notes
This is a small refactor, not a deletion-only PR, so it should be reviewed before merge.