### PR TITLE
chore: remove unused public surface

### DIFF
--- a/src/components/app/ImageApp.tsx
+++ b/src/components/app/ImageApp.tsx
@@ -72,5 +72,3 @@ export default function ImageApp() {
     </ImageAppProvider>
   );
 }
-
-export type { SizeDiff } from "@/components/app/state/ImageAppContext";

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -5,16 +5,6 @@
 
 import { ROUTES, GITHUB_URL } from "./constants";
 
-export interface NavLink {
-  label: string;
-  href: string;
-}
-
-export interface FooterSection {
-  title: string;
-  links: NavLink[];
-}
-
 export const navigation = {
   header: {
     links: [


### PR DESCRIPTION
## Summary
Removes a small amount of unused public surface from the codebase. This trims one unused type re-export from `ImageApp` and two unused navigation interfaces that were no longer referenced anywhere.

## Changes
- remove the unused `SizeDiff` re-export from `ImageApp`
- remove the unused `NavLink` and `FooterSection` interfaces from `src/config/navigation.ts`

## Testing
**Automated**
- [x] `bun run test` passed (142 tests)
- [x] `bun run verify` passed

## Notes
This is a deletion-only cleanup. If CI passes, it can be merged directly.