### PR TITLE
chore: remove unused format option

### DIFF
--- a/src/components/app/controls/FormatSelect.tsx
+++ b/src/components/app/controls/FormatSelect.tsx
@@ -2,15 +2,13 @@ import { useImageApp } from "@/components/app/state/ImageAppContext";
 import Select from "@/components/ui/Select";
 import { FORMAT_OPTIONS } from "@/config/selectOptions";
 
-const PROCESS_FORMAT_OPTIONS = FORMAT_OPTIONS.filter((option) => option.value !== "");
-
 export default function FormatSelect() {
   const { state, actions } = useImageApp();
 
   return (
     <Select
       id="format-select"
-      options={PROCESS_FORMAT_OPTIONS}
+      options={FORMAT_OPTIONS}
       value={state.formatValue()}
       onChange={actions.setFormatValue}
       disabled={!state.controlsActive() || state.formatSelectDisabled()}

--- a/src/components/ui/Select.test.tsx
+++ b/src/components/ui/Select.test.tsx
@@ -15,10 +15,10 @@ describe("Select", () => {
       <Select
         id="format-select"
         options={[
-          { value: "", label: "Keep original" },
           { value: "image/png", label: "PNG" },
+          { value: "image/webp", label: "WebP" },
         ]}
-        value=""
+        value="image/png"
         onChange={() => {}}
       />
     ));

--- a/src/config/selectOptions.ts
+++ b/src/config/selectOptions.ts
@@ -3,7 +3,6 @@ import { DPI_OPTIONS } from "./constants";
 import { CONVERTIBLE_OUTPUT_FORMATS, getImageFormatLabel } from "./imageFormats";
 
 export const FORMAT_OPTIONS: SelectOption[] = [
-  { value: "", label: "Keep original" },
   ...CONVERTIBLE_OUTPUT_FORMATS.map((f) => ({
     value: f,
     label: getImageFormatLabel(f),


### PR DESCRIPTION
## Summary
- remove the unused blank "Keep original" format option from shared select config
- simplify `FormatSelect` to use the shared format options directly
- update the shared select test fixture to use real output formats only

## Testing
- bun run verify