### PR TITLE
docs: align marketing content with product scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ Visit: https://reshrimp.vercel.app
 
 - **Client-side processing** - Your images never leave your device
 - **Offline-ready core tools** - The app shell, resize, convert, and compress flows work offline after the first online visit
-- **Image resizing** - Adjust dimensions with various options
+- **Image resizing** - Resize by pixels, percentage, or print units with aspect-ratio control
 - **Format conversion** - Convert between JPEG, PNG, WebP, and AVIF
 - **Compression** - Optimize file sizes while maintaining quality
 - **Background removal** - Runs locally and works offline after its mirrored model assets download once
-- **Single-image processing** - Upload once, adjust settings, and download the auto-processed result
+- **Single-image processing** - Upload one image, choose a few settings, and download the result
 - **Privacy first** - No server uploads, everything happens locally
 
 ## 🛠️ Tech Stack

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -21,7 +21,7 @@ import { GITHUB_URL, ROUTES } from "../config/constants";
   <MarketingPageWrapper>
     <HeroSection
       chip={{ label: "About", variant: "coral" }}
-      title="Built for privacy. Built to prove something bigger."
+      title="Built for privacy. Built to stay simple."
       subtitle="Reshrimp is a free, open source image processing tool that runs entirely in your browser. No uploads. No tracking. Just your images, processed locally."
     />
 
@@ -43,10 +43,9 @@ import { GITHUB_URL, ROUTES } from "../config/constants";
             can handle it locally in milliseconds?
           </p>
           <p class="text-[0.95rem] text-sp-text-muted leading-[1.7] mb-4 last:mb-0">
-            But Reshrimp is more than a privacy tool — it's also my portfolio project. I wanted to
-            build something genuinely useful that demonstrates my ability to ship real products with
-            modern web technologies. From AI-powered background removal to smooth animations, this
-            project showcases what I can do.
+            Reshrimp stays intentionally small on purpose. It focuses on fast, private,
+            browser-based work for one image at a time: resize, compress, convert, and background
+            removal.
           </p>
         </AboutCard>
 
@@ -78,8 +77,8 @@ import { GITHUB_URL, ROUTES } from "../config/constants";
           </p>
           <p class="text-[0.95rem] text-sp-text-muted leading-[1.7] mb-4 last:mb-0">
             Even AI background removal runs client-side using WebAssembly. Your images are processed
-            by your own device's CPU and GPU, not by someone else's servers. You can verify this
-            yourself — the code is open source under the MIT license.
+            on your own device, not on someone else's servers. You can verify this yourself — the
+            code is open source under the MIT license.
           </p>
         </AboutCard>
 

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -14,7 +14,7 @@ const faqs = [
   {
     question: "Is Reshrimp really free?",
     answer:
-      "Yes, completely free with no limits. No accounts, no premium tiers, no hidden costs. Reshrimp is open source under the MIT license and hosted for free on Vercel.",
+      "Yes. Reshrimp is free to use, with no accounts or premium tiers. It is open source under the MIT license.",
   },
   {
     question: "How does privacy work?",
@@ -38,7 +38,7 @@ const faqs = [
   },
   {
     question: "Where's the source code?",
-    answer: `The entire project is open source on <a href="${GITHUB_URL}" target="_blank" rel="noopener noreferrer">GitHub</a>. You can read, fork, or contribute to the code. The processing and workflow logic lives in TypeScript services that you can inspect directly.`,
+    answer: `The entire project is open source on <a href="${GITHUB_URL}" target="_blank" rel="noopener noreferrer">GitHub</a>. You can read, fork, or contribute to the code. The image-processing logic lives in TypeScript services that you can inspect directly.`,
   },
   {
     question: "Can I use it for commercial purposes?",

--- a/src/pages/features.astro
+++ b/src/pages/features.astro
@@ -69,9 +69,9 @@ const features = [
     <!-- Hero -->
     <HeroSection
       chip={{ label: "Features", variant: "lavender" }}
-      title="Everything you need."
-      gradientTitle="Nothing you don't."
-      subtitle="Reshrimp packs private image processing into a clean browser-based tool. After the first online visit, the app shell and core tools work offline."
+      title="Four focused tools."
+      gradientTitle="One image at a time."
+      subtitle="Reshrimp is a private browser utility for resize, compression, format conversion, and background removal. After the first online visit, the app shell and core tools work offline."
     />
 
     <!-- Feature sections -->

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -44,18 +44,15 @@ const jsonLd = {
         { label: "100% private", variant: "coral" },
         { label: "Offline-ready", variant: "lavender" },
       ]}
-      title="Your images deserve"
-      gradientTitle="better than the cloud."
+      title="Private image tools"
+      gradientTitle="that stay on your device."
       subtitle="Resize, convert, and compress images right in your browser. Nothing gets uploaded. Nothing gets tracked. After one online visit, the app shell and core tools work offline."
     >
       <HeroCTA secondaryText="No sign-up · Offline-ready" />
     </HeroSection>
 
     <PageSection sectionClass="px-8 py-16 relative z-10" containerClass="max-w-[1000px] mx-auto">
-      <MarketingSectionHeader
-        label="What can you do?"
-        title="Everything you need. Nothing you don't."
-      />
+      <MarketingSectionHeader label="What can you do?" title="Four focused tools for one image." />
       <BentoGrid>
         <BentoCard
           color="coral"
@@ -100,7 +97,7 @@ const jsonLd = {
           number={2}
           color="mint"
           title="Tweak the settings"
-          description="Set dimensions, pick a format, adjust quality, then process to review the result."
+          description="Set dimensions, pick a format, and adjust quality for the image you want to export."
           delay={200}
         />
         <StepArrow delay={300} />
@@ -108,7 +105,7 @@ const jsonLd = {
           number={3}
           color="lavender"
           title="Download instantly"
-          description="One click to process, one click to download. Compare before and after."
+          description="Process it, then download the result."
           delay={400}
         />
       </StepSection>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -89,8 +89,8 @@ import { GITHUB_URL } from "../config/constants";
             the MIT license. Every line of code is available for inspection.
           </p>
           <p class="text-[0.95rem] text-sp-text-muted leading-[1.7] mb-4 last:mb-0">
-            The image processing and workflow logic lives in TypeScript services that you can
-            inspect directly. Check the
+            The image-processing logic lives in TypeScript services that you can inspect directly.
+            Check the
             <a
               href={GITHUB_URL}
               target="_blank"


### PR DESCRIPTION
## Summary
- tighten README and marketing copy around the current single-image utility flow
- remove wording that implied comparison features, unlimited usage, or workflow-style product framing
- keep the change content-only with no layout or component behavior changes

## Testing
**Automated**
- [x] `bun run verify` passed