### PR TITLE
fix: avoid mid-session service worker takeover

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -12,7 +12,6 @@ export default defineConfig({
     solid(),
     sitemap(),
     AstroPWA({
-      registerType: "autoUpdate",
       strategies: "injectManifest",
       srcDir: "src",
       filename: "sw.ts",

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -6,7 +6,7 @@ import {
   BACKGROUND_REMOVAL_RUNTIME_CACHE_NAME,
   BACKGROUND_REMOVAL_SELF_HOSTED_CACHE_NAME,
 } from "./config/backgroundRemoval";
-import { clientsClaim, setCacheNameDetails } from "workbox-core";
+import { setCacheNameDetails } from "workbox-core";
 import { precacheAndRoute, cleanupOutdatedCaches } from "workbox-precaching";
 import { registerRoute } from "workbox-routing";
 import { CacheFirst } from "workbox-strategies";
@@ -17,9 +17,7 @@ declare let self: ServiceWorkerGlobalScope & {
 };
 
 setCacheNameDetails({ prefix: "reshrimp" });
-clientsClaim();
 cleanupOutdatedCaches();
-self.skipWaiting();
 
 precacheAndRoute(self.__WB_MANIFEST, {
   cleanURLs: true,


### PR DESCRIPTION
## Summary
- stop using the PWA auto-update takeover path for newly installed service workers
- remove unconditional `clientsClaim()` and `skipWaiting()` so open tabs keep their current in-memory session
- keep the existing waiting-worker message hook for any future explicit activation flow

## Testing
**Automated**
- [x] `bun run verify` passed