### PR TITLE
refactor: extract image app context helpers

### DIFF
--- a/src/components/app/preview/ImageInfoBar.tsx
+++ b/src/components/app/preview/ImageInfoBar.tsx
@@ -1,6 +1,6 @@
 import { Show } from "solid-js";
 import { formatFileSize } from "@/utils/imageUtils";
-import type { SizeDiff } from "@/components/app/state/ImageAppContext";
+import type { SizeDiff } from "@/components/app/state/imageAppTypes";
 
 interface ImageInfoBarProps {
   fileName: string;

--- a/src/components/app/state/ImageAppContext.tsx
+++ b/src/components/app/state/ImageAppContext.tsx
@@ -6,15 +6,12 @@ import {
   createSignal,
   on,
   onCleanup,
-  onMount,
   useContext,
-  type Accessor,
   type JSX,
 } from "solid-js";
 import type { ProcessedImage, ValidationResult, ImageFormat } from "@/types/image";
 import type { ProcessResult, ResizeUnit } from "@/types/processing";
 import { processImage, getImageMetadata } from "@/services/imageService";
-import { preloadBackgroundRemoval } from "@/services/backgroundRemovalService";
 import {
   buildProcessOptions,
   formatResizeValue,
@@ -27,11 +24,9 @@ import { validateImageFile, generateDownloadFilename } from "@/services/validati
 import { createDownloadLink, formatFileSize, convertFromPx } from "@/utils/imageUtils";
 import { DEFAULT_DPI } from "@/config/constants";
 import { getInitialOutputFormat, supportsBrowserQualityControl } from "@/config/imageFormats";
-
-export interface SizeDiff {
-  text: string;
-  className: string;
-}
+import type { AppActions, AppState, ImageAppContextValue, SizeDiff } from "./imageAppTypes";
+import { replaceProcessedObjectUrl, revokeImageSessionUrls } from "./imageAppObjectUrls";
+import { useBackgroundRemovalPreload } from "./useBackgroundRemovalPreload";
 
 function createDebouncedTask(fn: () => void, ms: number) {
   let timer: ReturnType<typeof setTimeout> | undefined;
@@ -48,92 +43,7 @@ function createDebouncedTask(fn: () => void, ms: number) {
   };
 }
 
-function scheduleIdleTask(callback: () => void): () => void {
-  if (typeof window === "undefined") return () => {};
-
-  const idleWindow = window as Window & {
-    requestIdleCallback?: (callback: IdleRequestCallback, options?: IdleRequestOptions) => number;
-    cancelIdleCallback?: (handle: number) => void;
-  };
-
-  if (
-    typeof idleWindow.requestIdleCallback === "function" &&
-    typeof idleWindow.cancelIdleCallback === "function"
-  ) {
-    const id = idleWindow.requestIdleCallback(() => callback(), { timeout: 1500 });
-    return () => idleWindow.cancelIdleCallback?.(id);
-  }
-
-  const id = globalThis.setTimeout(callback, 300);
-  return () => globalThis.clearTimeout(id);
-}
-
-function replaceObjectUrl(previousUrl: string | null, blob: Blob): string {
-  if (previousUrl) {
-    URL.revokeObjectURL(previousUrl);
-  }
-
-  return URL.createObjectURL(blob);
-}
-
-function revokeImageUrls(image: Pick<ProcessedImage, "originalUrl" | "processedUrl"> | null): void {
-  if (!image) {
-    return;
-  }
-
-  URL.revokeObjectURL(image.originalUrl);
-
-  if (image.processedUrl) {
-    URL.revokeObjectURL(image.processedUrl);
-  }
-}
-
-interface AppState {
-  currentImage: Accessor<ProcessedImage | null>;
-  processResult: Accessor<ProcessResult | null>;
-  isProcessing: Accessor<boolean>;
-  progressLabel: Accessor<string | null>;
-  error: Accessor<string | null>;
-  validation: Accessor<ValidationResult | null>;
-  isDragOver: Accessor<boolean>;
-  tooltipOpen: Accessor<boolean>;
-  dpiTooltipOpen: Accessor<boolean>;
-  widthValue: Accessor<string>;
-  heightValue: Accessor<string>;
-  maintainAspectRatio: Accessor<boolean>;
-  removeBackground: Accessor<boolean>;
-  formatValue: Accessor<string>;
-  previousFormatValue: Accessor<string>;
-  qualityValue: Accessor<number>;
-  resizeUnit: Accessor<ResizeUnit>;
-  dpiValue: Accessor<number>;
-  currentOutputFormat: Accessor<ImageFormat | null>;
-  qualityControlSupported: Accessor<boolean>;
-  controlsActive: Accessor<boolean>;
-  formatSelectDisabled: Accessor<boolean>;
-  downloadActive: Accessor<boolean>;
-  widthPlaceholder: Accessor<string>;
-  heightPlaceholder: Accessor<string>;
-  sizeDifference: Accessor<SizeDiff | null>;
-}
-
-interface AppActions {
-  handleFileUpload(file: File): Promise<void>;
-  handleDownload(): void;
-  handleRemoveBackgroundChange(checked: boolean): void;
-  handleUnitChange(unit: ResizeUnit): void;
-  handleDpiChange(dpi: number): void;
-  handleWidthInput(val: string): void;
-  handleHeightInput(val: string): void;
-  handleAspectRatioChange(checked: boolean): void;
-  setIsDragOver(v: boolean): void;
-  setTooltipOpen(v: boolean): void;
-  setDpiTooltipOpen(v: boolean): void;
-  setFormatValue(v: string): void;
-  setQualityValue(v: number): void;
-}
-
-const ImageAppContext = createContext<{ state: AppState; actions: AppActions }>();
+const ImageAppContext = createContext<ImageAppContextValue>();
 
 export function ImageAppProvider(props: { children: JSX.Element }) {
   // ── Core image state ──────────────────────────────────────────────────────
@@ -170,19 +80,10 @@ export function ImageAppProvider(props: { children: JSX.Element }) {
 
   onCleanup(() => {
     debouncedProcess.cancel();
-    revokeImageUrls(currentImage());
+    revokeImageSessionUrls(currentImage());
   });
 
-  // ── Preload background removal WASM + model once the app is idle ─────────
-  onMount(() => {
-    const cancelIdleTask = scheduleIdleTask(() => {
-      void preloadBackgroundRemoval().catch(() => {
-        // Silently ignore preload failures — will retry on actual use.
-      });
-    });
-
-    onCleanup(cancelIdleTask);
-  });
+  useBackgroundRemovalPreload();
 
   // ── Derived signals ───────────────────────────────────────────────────────
   const controlsActive = createMemo(() => currentImage() !== null);
@@ -269,7 +170,7 @@ export function ImageAppProvider(props: { children: JSX.Element }) {
           : undefined
       );
 
-      const processedUrl = replaceObjectUrl(img.processedUrl, result.blob);
+      const processedUrl = replaceProcessedObjectUrl(img.processedUrl, result.blob);
 
       // Batch result updates into a single DOM update
       batch(() => {
@@ -338,7 +239,7 @@ export function ImageAppProvider(props: { children: JSX.Element }) {
       batch(() => {
         // Reset stale state when a new file is loaded
         setCurrentImage((previousImage) => {
-          revokeImageUrls(previousImage);
+          revokeImageSessionUrls(previousImage);
           return processedImage;
         });
         setProcessResult(null);

--- a/src/components/app/state/imageAppObjectUrls.ts
+++ b/src/components/app/state/imageAppObjectUrls.ts
@@ -1,0 +1,23 @@
+import type { ProcessedImage } from "@/types/image";
+
+export function replaceProcessedObjectUrl(previousUrl: string | null, blob: Blob): string {
+  if (previousUrl) {
+    URL.revokeObjectURL(previousUrl);
+  }
+
+  return URL.createObjectURL(blob);
+}
+
+export function revokeImageSessionUrls(
+  image: Pick<ProcessedImage, "originalUrl" | "processedUrl"> | null
+): void {
+  if (!image) {
+    return;
+  }
+
+  URL.revokeObjectURL(image.originalUrl);
+
+  if (image.processedUrl) {
+    URL.revokeObjectURL(image.processedUrl);
+  }
+}

--- a/src/components/app/state/imageAppTypes.ts
+++ b/src/components/app/state/imageAppTypes.ts
@@ -1,0 +1,58 @@
+import type { Accessor } from "solid-js";
+import type { ProcessedImage, ValidationResult, ImageFormat } from "@/types/image";
+import type { ProcessResult, ResizeUnit } from "@/types/processing";
+
+export interface SizeDiff {
+  text: string;
+  className: string;
+}
+
+export interface AppState {
+  currentImage: Accessor<ProcessedImage | null>;
+  processResult: Accessor<ProcessResult | null>;
+  isProcessing: Accessor<boolean>;
+  progressLabel: Accessor<string | null>;
+  error: Accessor<string | null>;
+  validation: Accessor<ValidationResult | null>;
+  isDragOver: Accessor<boolean>;
+  tooltipOpen: Accessor<boolean>;
+  dpiTooltipOpen: Accessor<boolean>;
+  widthValue: Accessor<string>;
+  heightValue: Accessor<string>;
+  maintainAspectRatio: Accessor<boolean>;
+  removeBackground: Accessor<boolean>;
+  formatValue: Accessor<string>;
+  previousFormatValue: Accessor<string>;
+  qualityValue: Accessor<number>;
+  resizeUnit: Accessor<ResizeUnit>;
+  dpiValue: Accessor<number>;
+  currentOutputFormat: Accessor<ImageFormat | null>;
+  qualityControlSupported: Accessor<boolean>;
+  controlsActive: Accessor<boolean>;
+  formatSelectDisabled: Accessor<boolean>;
+  downloadActive: Accessor<boolean>;
+  widthPlaceholder: Accessor<string>;
+  heightPlaceholder: Accessor<string>;
+  sizeDifference: Accessor<SizeDiff | null>;
+}
+
+export interface AppActions {
+  handleFileUpload(file: File): Promise<void>;
+  handleDownload(): void;
+  handleRemoveBackgroundChange(checked: boolean): void;
+  handleUnitChange(unit: ResizeUnit): void;
+  handleDpiChange(dpi: number): void;
+  handleWidthInput(val: string): void;
+  handleHeightInput(val: string): void;
+  handleAspectRatioChange(checked: boolean): void;
+  setIsDragOver(v: boolean): void;
+  setTooltipOpen(v: boolean): void;
+  setDpiTooltipOpen(v: boolean): void;
+  setFormatValue(v: string): void;
+  setQualityValue(v: number): void;
+}
+
+export interface ImageAppContextValue {
+  state: AppState;
+  actions: AppActions;
+}

--- a/src/components/app/state/useBackgroundRemovalPreload.ts
+++ b/src/components/app/state/useBackgroundRemovalPreload.ts
@@ -1,0 +1,34 @@
+import { onCleanup, onMount } from "solid-js";
+import { preloadBackgroundRemoval } from "@/services/backgroundRemovalService";
+
+function scheduleIdleTask(callback: () => void): () => void {
+  if (typeof window === "undefined") return () => {};
+
+  const idleWindow = window as Window & {
+    requestIdleCallback?: (callback: IdleRequestCallback, options?: IdleRequestOptions) => number;
+    cancelIdleCallback?: (handle: number) => void;
+  };
+
+  if (
+    typeof idleWindow.requestIdleCallback === "function" &&
+    typeof idleWindow.cancelIdleCallback === "function"
+  ) {
+    const id = idleWindow.requestIdleCallback(() => callback(), { timeout: 1500 });
+    return () => idleWindow.cancelIdleCallback?.(id);
+  }
+
+  const id = globalThis.setTimeout(callback, 300);
+  return () => globalThis.clearTimeout(id);
+}
+
+export function useBackgroundRemovalPreload(): void {
+  onMount(() => {
+    const cancelIdleTask = scheduleIdleTask(() => {
+      void preloadBackgroundRemoval().catch(() => {
+        // Silently ignore preload failures — will retry on actual use.
+      });
+    });
+
+    onCleanup(cancelIdleTask);
+  });
+}


### PR DESCRIPTION
## Summary
- extract `ImageAppContext` leaf concerns into focused state modules without changing the public context API
- move context contracts into `imageAppTypes.ts` and object URL/session helpers into `imageAppObjectUrls.ts`
- isolate background-removal idle preload in `useBackgroundRemovalPreload.ts` so the provider stays focused on the single-image workflow

## Testing
**Automated**
- [x] `bun run verify` passed

## Notes
This is intentionally the first step only. The provider contract and app behavior stay the same, but the internal structure is easier to review and extend in smaller follow-up refactors.