### PR TITLE
fix: correct AVIF quality copy and remove dormant code

### DIFF
--- a/src/config/backgroundRemoval.ts
+++ b/src/config/backgroundRemoval.ts
@@ -1,4 +1,4 @@
-export const BACKGROUND_REMOVAL_DATA_VERSION = "1.7.0";
+const BACKGROUND_REMOVAL_DATA_VERSION = "1.7.0";
 export const BACKGROUND_REMOVAL_MODEL = "isnet_fp16";
 
 /**
@@ -7,17 +7,6 @@ export const BACKGROUND_REMOVAL_MODEL = "isnet_fp16";
  * full upstream asset package.
  */
 export const BACKGROUND_REMOVAL_ASSET_PATH_PREFIX = `/background-removal/${BACKGROUND_REMOVAL_DATA_VERSION}/dist/`;
-
-/**
- * The mirror step pulls only the current CPU runtime and fp16 model from the
- * upstream CDN. Alternate models and GPU/runtime variants stay excluded to keep
- * deployment size manageable.
- */
-export const BACKGROUND_REMOVAL_ASSET_KEYS = [
-  "/onnxruntime-web/ort-wasm-simd-threaded.wasm",
-  "/onnxruntime-web/ort-wasm-simd-threaded.mjs",
-  `/models/${BACKGROUND_REMOVAL_MODEL}`,
-] as const;
 
 export const BACKGROUND_REMOVAL_SELF_HOSTED_CACHE_NAME = "imgly-background-removal-self-hosted";
 export const BACKGROUND_REMOVAL_RUNTIME_CACHE_NAME = "imgly-background-removal-runtime";

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -8,7 +8,6 @@ export const GITHUB_URL = "https://github.com/abijith-suresh/reshrimp";
 
 // Site metadata
 export const SITE_NAME = "Reshrimp";
-export const SITE_TAGLINE = "Privacy-first image processing in your browser";
 export const SITE_DESCRIPTION =
   "Resize, convert, and compress images right in your browser. Nothing gets uploaded. Nothing gets tracked.";
 

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -43,9 +43,8 @@ import { GITHUB_URL, ROUTES } from "../config/constants";
             can handle it locally in milliseconds?
           </p>
           <p class="text-[0.95rem] text-sp-text-muted leading-[1.7] mb-4 last:mb-0">
-            Reshrimp stays intentionally small on purpose. It focuses on fast, private,
-            browser-based work for one image at a time: resize, compress, convert, and background
-            removal.
+            Reshrimp stays intentionally small. It focuses on fast, private, browser-based work for
+            one image at a time: resize, compress, convert, and background removal.
           </p>
         </AboutCard>
 

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -48,7 +48,7 @@ const faqs = [
   {
     question: "How do the quality settings work?",
     answer:
-      "The quality slider controls JPEG and WebP output (0-100%). PNG export stays lossless, and this app's browser-native AVIF export uses fixed encoder settings. The preview updates after processing so you can review the result before downloading.",
+      "The quality slider controls JPEG, WebP, and AVIF output (0-100%) through your browser's built-in encoding. PNG export stays lossless. The preview updates after processing so you can review the result before downloading.",
   },
 ];
 ---

--- a/src/pages/features.astro
+++ b/src/pages/features.astro
@@ -13,7 +13,7 @@ const features = [
     title: "Resize with precision",
     color: "coral",
     description:
-      "Scale images to exact pixel dimensions with intelligent aspect ratio lock. Perfect for social media thumbnails, website banners, or print-ready exports. Set width, height, or both — calculator handles the math.",
+      "Scale images to exact pixel dimensions with aspect ratio lock. Perfect for uploads, websites, or sharing. Set width, height, or both — the calculator handles the math.",
   },
   {
     icon: ArrowLeftRight,
@@ -27,7 +27,7 @@ const features = [
     title: "Smart compression",
     color: "lavender",
     description:
-      "Fine-tune quality for JPEG and WebP before processing, then review the updated preview before downloading. PNG stays lossless, and AVIF uses browser-native encoder defaults in this app.",
+      "Fine-tune quality for JPEG, WebP, and AVIF before processing, then review the updated preview before downloading. PNG stays lossless.",
   },
   {
     icon: ShieldCheck,
@@ -55,7 +55,7 @@ const features = [
     title: "Remove background",
     color: "lavender",
     description:
-      "AI-powered background removal that runs in your browser using WebAssembly. It downloads model assets once, then works offline and exports PNG to preserve transparency.",
+      "Browser-based background removal using WebAssembly. Downloads model assets once, then works offline. Exports PNG to preserve transparency.",
   },
 ];
 ---

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -59,7 +59,7 @@ const jsonLd = {
           colSpan={true}
           icon={Scaling}
           title="Resize with precision"
-          description="Scale to exact pixel dimensions. Aspect ratio lock keeps everything balanced. Works for thumbnails, social media, or high-res exports."
+          description="Scale to exact pixel dimensions. Aspect ratio lock keeps everything balanced. Works for uploads, websites, or sharing."
         />
         <BentoCard
           color="mint"
@@ -71,7 +71,7 @@ const jsonLd = {
           color="lavender"
           icon={Gauge}
           title="Compress smartly"
-          description="Fine-tune JPEG and WebP quality from 0-100%. PNG stays lossless, while AVIF uses browser-native defaults in this app."
+          description="Fine-tune JPEG, WebP, and AVIF quality from 0-100%. PNG stays lossless. Preview updates after processing so you can review the result before downloading."
         />
         <BentoCard
           color="yellow"


### PR DESCRIPTION
## Summary
The AVIF quality slider is fully functional — the code passes quality to `canvas.toBlob()` for AVIF just like JPEG and WebP. Marketing copy falsely claimed AVIF used "fixed encoder settings." This PR corrects that across landing, features, and FAQ pages. It also aligns remaining copy with `docs/CONTEXT.md` (removes "print-ready exports," "AI-powered" hype, redundant phrasing) and removes two unused exports found during audit.

## Changes
- Fix AVIF quality-control copy: replace "fixed encoder settings" claims with accurate description across landing, features, and FAQ
- Align marketing copy with CONTEXT.md: replace exaggerated use cases ("print-ready," "high-res exports") with honest language ("uploads, websites, sharing")
- Remove "AI-powered" hype from background removal description
- Remove unused `SITE_TAGLINE` export from constants
- Remove unused `BACKGROUND_REMOVAL_ASSET_KEYS` export, unexport `BACKGROUND_REMOVAL_DATA_VERSION`
- Fix "intentionally small on purpose" redundancy on about page

## Testing
**Automated**
- [x] `bun run verify` passed (16 test files, 145 tests, type-check, lint, format, build)

**Manual**
- [ ] Review landing, features, about, and FAQ pages for copy accuracy