### PR TITLE
feat: softpop design system migration with oklch tokens

### DIFF
--- a/src/components/app/AppSidebar.tsx
+++ b/src/components/app/AppSidebar.tsx
@@ -5,24 +5,24 @@ import { makeHref } from "@/lib/utils";
 export default function AppSidebar() {
   return (
     <nav
-      class="hidden md:flex flex-col items-center w-12 bg-sp-bg-card border-r border-sp-border py-4 gap-1 shrink-0"
+      class="hidden md:flex flex-col items-center w-12 bg-card border-r border-border py-4 gap-1 shrink-0"
       aria-label="App navigation"
     >
       <a
         href={makeHref(ROUTES.HOME)}
-        class="flex items-center justify-center w-8 h-8 rounded-sp transition-colors duration-200 hover:bg-sp-coral-light group mb-2 focus-visible:ring-2 focus-visible:ring-sp-lavender/40"
+        class="flex items-center justify-center w-8 h-8 rounded-md transition-colors duration-200 hover:bg-coral-50 group mb-2 focus-visible:ring-2 focus-visible:ring-lavender-500/40"
         aria-label="Back to home"
       >
-        <span class="w-3 h-3 rounded-full bg-sp-coral transition-transform duration-300 group-hover:scale-125 shrink-0" />
+        <span class="w-3 h-3 rounded-full bg-coral-500 transition-transform duration-300 group-hover:scale-125 shrink-0" />
       </a>
 
-      <div class="w-6 h-px bg-sp-border-light" />
+      <div class="w-6 h-px bg-border-light" />
 
       <div class="flex-1" />
 
       <a
         href={makeHref(ROUTES.ABOUT)}
-        class="flex items-center justify-center w-8 h-8 rounded-sp text-sp-text-soft hover:text-sp-text-muted hover:bg-sp-bg transition-colors duration-200 focus-visible:ring-2 focus-visible:ring-sp-lavender/40"
+        class="flex items-center justify-center w-8 h-8 rounded-md text-soft-foreground hover:text-muted-foreground hover:bg-background transition-colors duration-200 focus-visible:ring-2 focus-visible:ring-lavender-500/40"
         aria-label="About Reshrimp"
         title="About"
       >

--- a/src/components/app/FloatingBackButton.tsx
+++ b/src/components/app/FloatingBackButton.tsx
@@ -6,7 +6,7 @@ export default function FloatingBackButton() {
   return (
     <a
       href={makeHref(ROUTES.HOME)}
-      class="md:hidden fixed top-4 left-4 z-50 flex items-center gap-1.5 px-3 py-2 bg-sp-coral text-white text-[0.75rem] font-semibold rounded-sp-full shadow-[0_4px_14px_rgba(242,90,90,0.35)] hover:bg-sp-coral-dark active:scale-95 transition-[background-color,transform] duration-200 focus-visible:ring-2 focus-visible:ring-sp-lavender focus-visible:ring-offset-2"
+      class="md:hidden fixed top-4 left-4 z-50 flex items-center gap-1.5 px-3 py-2 bg-coral-500 text-white text-[0.75rem] font-semibold rounded-full shadow-[0_4px_14px_rgba(242,90,90,0.35)] hover:bg-coral-600 active:scale-95 transition-[background-color,transform] duration-200 focus-visible:ring-2 focus-visible:ring-lavender-500 focus-visible:ring-offset-2"
       aria-label="Back to home"
     >
       <ArrowLeft class="w-3.5 h-3.5" aria-hidden="true" />

--- a/src/components/app/FloatingBackButton.tsx
+++ b/src/components/app/FloatingBackButton.tsx
@@ -6,7 +6,7 @@ export default function FloatingBackButton() {
   return (
     <a
       href={makeHref(ROUTES.HOME)}
-      class="md:hidden fixed top-4 left-4 z-50 flex items-center gap-1.5 px-3 py-2 bg-coral-500 text-white text-[0.75rem] font-semibold rounded-full shadow-[0_4px_14px_rgba(242,90,90,0.35)] hover:bg-coral-600 active:scale-95 transition-[background-color,transform] duration-200 focus-visible:ring-2 focus-visible:ring-lavender-500 focus-visible:ring-offset-2"
+      class="md:hidden fixed top-4 left-4 z-50 flex items-center gap-1.5 px-3 py-2 bg-coral-500 text-white text-xs font-semibold rounded-full shadow-[0_4px_14px_rgba(242,90,90,0.35)] hover:bg-coral-600 active:scale-95 transition-[background-color,transform] duration-200 focus-visible:ring-2 focus-visible:ring-lavender-500 focus-visible:ring-offset-2"
       aria-label="Back to home"
     >
       <ArrowLeft class="w-3.5 h-3.5" aria-hidden="true" />

--- a/src/components/app/ImageApp.tsx
+++ b/src/components/app/ImageApp.tsx
@@ -76,7 +76,7 @@ function MobileSheet() {
       <Show when={sheetState() === "open"}>
         <button
           type="button"
-          class="md:hidden fixed inset-0 z-30 bg-black/20 border-none cursor-pointer focus-visible:ring-2 focus-visible:ring-sp-lavender/40 focus-visible:ring-offset-2"
+          class="md:hidden fixed inset-0 z-30 bg-black/20 border-none cursor-pointer focus-visible:ring-2 focus-visible:ring-lavender-500/40 focus-visible:ring-offset-2"
           onClick={() => setSheetState("peek")}
           aria-label="Close controls"
           onKeyDown={(e) => {
@@ -90,7 +90,7 @@ function MobileSheet() {
         role="region"
         aria-label="Image controls"
         aria-hidden={sheetState() === "hidden" ? "true" : "false"}
-        class="md:hidden fixed inset-x-0 bottom-0 z-40 flex flex-col bg-sp-bg-card rounded-t-[22px] sp-mobile-sheet"
+        class="md:hidden fixed inset-x-0 bottom-0 z-40 flex flex-col bg-card rounded-t-[22px] mobile-sheet"
         style={{
           transform: translateForState(sheetState()),
           transition: SPRING,
@@ -101,17 +101,17 @@ function MobileSheet() {
           {/* Handle pill — tap to toggle between peek and open */}
           <button
             type="button"
-            class="w-full pt-3 pb-2 flex flex-col items-center cursor-pointer active:opacity-60 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-sp-lavender/40 rounded-t-[22px] transition-opacity duration-150"
+            class="w-full pt-3 pb-2 flex flex-col items-center cursor-pointer active:opacity-60 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-lavender-500/40 rounded-t-[22px] transition-opacity duration-150"
             style={{ "touch-action": "manipulation" }}
             onClick={toggleSheet}
             aria-label={sheetState() === "open" ? "Minimise controls" : "Open controls"}
           >
             {/* Pill — widens and turns lavender when open as a state hint */}
             <div
-              class="rounded-full transition-[width,background] duration-300 sp-mobile-sheet-handle"
+              class="rounded-full transition-[width,background] duration-300 mobile-sheet-handle"
               style={{
                 width: sheetState() === "open" ? "28px" : "40px",
-                background: sheetState() === "open" ? "var(--sp-lavender)" : "var(--sp-border)",
+                background: sheetState() === "open" ? "var(--lavender-500)" : "var(--border)",
               }}
             />
           </button>
@@ -132,13 +132,13 @@ function MobileSheet() {
           </Show>
 
           {/* Download button — primary CTA always reachable without opening */}
-          <div class="px-4 pt-1 sp-mobile-sheet-footer">
+          <div class="px-4 pt-1 mobile-sheet-footer">
             <DownloadSection />
           </div>
         </div>
 
         {/* Hairline divider between header and content */}
-        <div class="mx-4 h-px bg-sp-border-light shrink-0" />
+        <div class="mx-4 h-px bg-border-light shrink-0" />
 
         {/* Scrollable settings content */}
         <div
@@ -162,12 +162,12 @@ function MobileSheet() {
 export default function ImageApp() {
   return (
     <ImageAppProvider>
-      <div class="h-dvh overflow-hidden flex flex-row bg-sp-bg">
+      <div class="h-dvh overflow-hidden flex flex-row bg-background">
         {/* Desktop icon dock */}
         <AppSidebar />
 
         {/* Control panel — desktop only */}
-        <div class="hidden md:flex flex-col w-[320px] border-r border-sp-border bg-sp-bg-card overflow-hidden shrink-0">
+        <div class="hidden md:flex flex-col w-[320px] border-r border-border bg-card overflow-hidden shrink-0">
           <div class="flex flex-col flex-1 overflow-hidden min-h-0">
             <ProcessPanel />
           </div>

--- a/src/components/app/PreviewPanel.tsx
+++ b/src/components/app/PreviewPanel.tsx
@@ -69,9 +69,7 @@ export default function PreviewPanel() {
                     {(label) => (
                       <div class="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-background/80 rounded-md">
                         <span class="btn-spinner" aria-hidden="true" />
-                        <span class="text-[0.8rem] text-muted-foreground font-medium">
-                          {label()}
-                        </span>
+                        <span class="text-xs text-muted-foreground font-medium">{label()}</span>
                       </div>
                     )}
                   </Show>

--- a/src/components/app/PreviewPanel.tsx
+++ b/src/components/app/PreviewPanel.tsx
@@ -21,7 +21,7 @@ export default function PreviewPanel() {
   }
 
   return (
-    <div class="h-full flex flex-col bg-sp-bg overflow-hidden">
+    <div class="h-full flex flex-col bg-background overflow-hidden">
       {/* Hidden file input for the mobile EmptyState upload button */}
       <input
         ref={(el) => {
@@ -67,9 +67,11 @@ export default function PreviewPanel() {
 
                   <Show when={state.isProcessing() && state.progressLabel()}>
                     {(label) => (
-                      <div class="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-sp-bg/80 rounded-sp">
-                        <span class="sp-btn-spinner" aria-hidden="true" />
-                        <span class="text-[0.8rem] text-sp-text-muted font-medium">{label()}</span>
+                      <div class="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-background/80 rounded-md">
+                        <span class="btn-spinner" aria-hidden="true" />
+                        <span class="text-[0.8rem] text-muted-foreground font-medium">
+                          {label()}
+                        </span>
                       </div>
                     )}
                   </Show>

--- a/src/components/app/UploadArea.tsx
+++ b/src/components/app/UploadArea.tsx
@@ -54,7 +54,7 @@ export default function UploadArea() {
           onClick={(e) => e.stopPropagation()}
           onChange={handleFileInput}
         />
-        <p class="text-[0.7rem] text-soft-foreground m-0 mt-1">
+        <p class="text-xs text-soft-foreground m-0 mt-1">
           JPEG, PNG, WebP · max {formatFileSize(MAX_FILE_SIZE)}
         </p>
         <ValidationMessages validation={state.validation()} />

--- a/src/components/app/UploadArea.tsx
+++ b/src/components/app/UploadArea.tsx
@@ -54,7 +54,7 @@ export default function UploadArea() {
           onClick={(e) => e.stopPropagation()}
           onChange={handleFileInput}
         />
-        <p class="text-[0.7rem] text-sp-text-soft m-0 mt-1">
+        <p class="text-[0.7rem] text-soft-foreground m-0 mt-1">
           JPEG, PNG, WebP · max {formatFileSize(MAX_FILE_SIZE)}
         </p>
         <ValidationMessages validation={state.validation()} />

--- a/src/components/app/controls/QualitySection.tsx
+++ b/src/components/app/controls/QualitySection.tsx
@@ -9,7 +9,7 @@ export default function QualitySection() {
       <div class="flex items-center justify-between gap-3">
         <SectionHeader>Quality</SectionHeader>
         {state.qualityControlSupported() ? (
-          <span class="text-[0.85rem] font-semibold text-coral-500">{state.qualityValue()}%</span>
+          <span class="text-sm font-semibold text-coral-500">{state.qualityValue()}%</span>
         ) : null}
       </div>
       <label for="quality-slider" class="sr-only">

--- a/src/components/app/controls/QualitySection.tsx
+++ b/src/components/app/controls/QualitySection.tsx
@@ -9,7 +9,7 @@ export default function QualitySection() {
       <div class="flex items-center justify-between gap-3">
         <SectionHeader>Quality</SectionHeader>
         {state.qualityControlSupported() ? (
-          <span class="text-[0.85rem] font-semibold text-sp-coral">{state.qualityValue()}%</span>
+          <span class="text-[0.85rem] font-semibold text-coral-500">{state.qualityValue()}%</span>
         ) : null}
       </div>
       <label for="quality-slider" class="sr-only">
@@ -21,7 +21,7 @@ export default function QualitySection() {
         min={1}
         max={100}
         value={state.qualityValue()}
-        class="w-full h-1.5 rounded-[3px] appearance-none bg-sp-border-light cursor-pointer sp-slider"
+        class="w-full h-1.5 rounded-[3px] appearance-none bg-border-light cursor-pointer slider"
         disabled={!state.controlsActive() || !state.qualityControlSupported()}
         onInput={(e) => actions.setQualityValue(parseInt((e.target as HTMLInputElement).value, 10))}
       />

--- a/src/components/app/panels/ProcessPanel.tsx
+++ b/src/components/app/panels/ProcessPanel.tsx
@@ -24,7 +24,7 @@ export default function ProcessPanel(props: ProcessPanelProps) {
   const showDpi = () => state.resizeUnit() === "in" || state.resizeUnit() === "cm";
 
   const sourceSection = (
-    <div class="flex flex-col gap-2 border-b border-sp-border-light px-5 py-3 pt-5 pb-3">
+    <div class="flex flex-col gap-2 border-b border-border-light px-5 py-3 pt-5 pb-3">
       <SectionHeader>Source</SectionHeader>
       <div class="mt-2">
         <UploadArea />
@@ -33,7 +33,7 @@ export default function ProcessPanel(props: ProcessPanelProps) {
   );
 
   const geometrySection = (
-    <div class="flex flex-col gap-2 border-b border-sp-border-light px-5 py-3">
+    <div class="flex flex-col gap-2 border-b border-border-light px-5 py-3">
       <SectionHeader>Geometry</SectionHeader>
       <DimensionInputs />
       <div class="flex gap-2">
@@ -51,14 +51,14 @@ export default function ProcessPanel(props: ProcessPanelProps) {
   );
 
   const formatSection = (
-    <div class="flex flex-col gap-2 border-b border-sp-border-light px-5 py-3">
+    <div class="flex flex-col gap-2 border-b border-border-light px-5 py-3">
       <SectionHeader>Format</SectionHeader>
       <FormatSelect />
     </div>
   );
 
   const qualitySection = (
-    <div class="flex flex-col gap-3 border-b border-sp-border-light px-5 py-3">
+    <div class="flex flex-col gap-3 border-b border-border-light px-5 py-3">
       <QualitySection />
     </div>
   );

--- a/src/components/app/preview/EmptyState.tsx
+++ b/src/components/app/preview/EmptyState.tsx
@@ -16,15 +16,17 @@ export default function EmptyState(props: EmptyStateProps) {
       id="sbs-empty-state"
       class="flex-1 flex flex-col items-center justify-center text-center p-8 transition-opacity duration-300"
     >
-      {props.icon ?? <Image class="w-12 h-12 text-sp-text-soft opacity-30 mb-3" />}
-      <p class="font-body text-[0.9rem] font-medium text-sp-text-muted m-0 mb-1">{props.title}</p>
-      <p class="text-[0.8rem] text-sp-text-soft m-0">{props.subtitle}</p>
+      {props.icon ?? <Image class="w-12 h-12 text-soft-foreground opacity-30 mb-3" />}
+      <p class="font-body text-[0.9rem] font-medium text-muted-foreground m-0 mb-1">
+        {props.title}
+      </p>
+      <p class="text-[0.8rem] text-soft-foreground m-0">{props.subtitle}</p>
 
       <Show when={props.onUploadClick}>
         {/* Mobile-only upload CTA — on desktop the sidebar UploadArea is always visible */}
         <button
           type="button"
-          class="mt-6 md:hidden inline-flex items-center gap-2 px-5 py-2.5 bg-sp-coral text-white text-[0.85rem] font-semibold rounded-sp-full shadow-[0_4px_14px_rgba(242,90,90,0.3)] hover:bg-sp-coral-dark active:scale-95 transition-[background-color,transform] duration-200 focus-visible:ring-2 focus-visible:ring-sp-lavender focus-visible:ring-offset-2"
+          class="mt-6 md:hidden inline-flex items-center gap-2 px-5 py-2.5 bg-coral-500 text-white text-[0.85rem] font-semibold rounded-full shadow-[0_4px_14px_rgba(242,90,90,0.3)] hover:bg-coral-600 active:scale-95 transition-[background-color,transform] duration-200 focus-visible:ring-2 focus-visible:ring-lavender-500 focus-visible:ring-offset-2"
           onClick={() => props.onUploadClick?.()}
         >
           <Upload class="w-4 h-4" aria-hidden="true" />

--- a/src/components/app/preview/EmptyState.tsx
+++ b/src/components/app/preview/EmptyState.tsx
@@ -17,16 +17,14 @@ export default function EmptyState(props: EmptyStateProps) {
       class="flex-1 flex flex-col items-center justify-center text-center p-8 transition-opacity duration-300"
     >
       {props.icon ?? <Image class="w-12 h-12 text-soft-foreground opacity-30 mb-3" />}
-      <p class="font-body text-[0.9rem] font-medium text-muted-foreground m-0 mb-1">
-        {props.title}
-      </p>
-      <p class="text-[0.8rem] text-soft-foreground m-0">{props.subtitle}</p>
+      <p class="font-body text-sm font-medium text-muted-foreground m-0 mb-1">{props.title}</p>
+      <p class="text-xs text-soft-foreground m-0">{props.subtitle}</p>
 
       <Show when={props.onUploadClick}>
         {/* Mobile-only upload CTA — on desktop the sidebar UploadArea is always visible */}
         <button
           type="button"
-          class="mt-6 md:hidden inline-flex items-center gap-2 px-5 py-2.5 bg-coral-500 text-white text-[0.85rem] font-semibold rounded-full shadow-[0_4px_14px_rgba(242,90,90,0.3)] hover:bg-coral-600 active:scale-95 transition-[background-color,transform] duration-200 focus-visible:ring-2 focus-visible:ring-lavender-500 focus-visible:ring-offset-2"
+          class="mt-6 md:hidden inline-flex items-center gap-2 px-5 py-2.5 bg-coral-500 text-white text-sm font-semibold rounded-full shadow-[0_4px_14px_rgba(242,90,90,0.3)] hover:bg-coral-600 active:scale-95 transition-[background-color,transform] duration-200 focus-visible:ring-2 focus-visible:ring-lavender-500 focus-visible:ring-offset-2"
           onClick={() => props.onUploadClick?.()}
         >
           <Upload class="w-4 h-4" aria-hidden="true" />

--- a/src/components/app/preview/ErrorDisplay.tsx
+++ b/src/components/app/preview/ErrorDisplay.tsx
@@ -8,10 +8,10 @@ export default function ErrorDisplay(props: ErrorDisplayProps) {
   return (
     <div id="error-message" class="error-container">
       <div class="flex gap-3">
-        <AlertCircle class="w-5 h-5 text-sp-coral shrink-0 mt-0.5" aria-hidden="true" />
+        <AlertCircle class="w-5 h-5 text-coral-500 shrink-0 mt-0.5" aria-hidden="true" />
         <div>
-          <h3 class="text-[0.85rem] font-semibold text-sp-coral-dark m-0 mb-1">Processing Error</h3>
-          <p id="error-text" class="text-[0.8rem] text-sp-coral m-0">
+          <h3 class="text-[0.85rem] font-semibold text-coral-600 m-0 mb-1">Processing Error</h3>
+          <p id="error-text" class="text-[0.8rem] text-coral-500 m-0">
             {props.message}
           </p>
         </div>

--- a/src/components/app/preview/ErrorDisplay.tsx
+++ b/src/components/app/preview/ErrorDisplay.tsx
@@ -10,8 +10,8 @@ export default function ErrorDisplay(props: ErrorDisplayProps) {
       <div class="flex gap-3">
         <AlertCircle class="w-5 h-5 text-coral-500 shrink-0 mt-0.5" aria-hidden="true" />
         <div>
-          <h3 class="text-[0.85rem] font-semibold text-coral-600 m-0 mb-1">Processing Error</h3>
-          <p id="error-text" class="text-[0.8rem] text-coral-500 m-0">
+          <h3 class="text-sm font-semibold text-coral-600 m-0 mb-1">Processing Error</h3>
+          <p id="error-text" class="text-xs text-coral-500 m-0">
             {props.message}
           </p>
         </div>

--- a/src/components/app/preview/ImageInfoBar.tsx
+++ b/src/components/app/preview/ImageInfoBar.tsx
@@ -14,7 +14,7 @@ export default function ImageInfoBar(props: ImageInfoBarProps) {
   return (
     <div
       data-testid="info-strip"
-      class="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[0.78rem] text-muted-foreground bg-lavender-50 border-t border-border-light rounded-md px-3.5 py-2 shrink-0"
+      class="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-muted-foreground bg-lavender-50 border-t border-border-light rounded-md px-3.5 py-2 shrink-0"
     >
       <span class="font-semibold text-foreground max-w-[180px] truncate">{props.fileName}</span>
       <span class="text-border" aria-hidden="true">

--- a/src/components/app/preview/ImageInfoBar.tsx
+++ b/src/components/app/preview/ImageInfoBar.tsx
@@ -14,23 +14,23 @@ export default function ImageInfoBar(props: ImageInfoBarProps) {
   return (
     <div
       data-testid="info-strip"
-      class="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[0.78rem] text-sp-text-muted bg-sp-lavender-light border-t border-sp-border-light rounded-sp px-3.5 py-2 shrink-0"
+      class="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[0.78rem] text-muted-foreground bg-lavender-50 border-t border-border-light rounded-md px-3.5 py-2 shrink-0"
     >
-      <span class="font-semibold text-sp-text max-w-[180px] truncate">{props.fileName}</span>
-      <span class="text-sp-border" aria-hidden="true">
+      <span class="font-semibold text-foreground max-w-[180px] truncate">{props.fileName}</span>
+      <span class="text-border" aria-hidden="true">
         ·
       </span>
       <span>
         {props.width} &times; {props.height}px
       </span>
-      <span class="text-sp-border" aria-hidden="true">
+      <span class="text-border" aria-hidden="true">
         ·
       </span>
       <span>{formatFileSize(props.fileSize)}</span>
       <Show when={props.sizeDiff}>
         {(diff) => (
           <>
-            <span class="text-sp-border" aria-hidden="true">
+            <span class="text-border" aria-hidden="true">
               ·
             </span>
             <span id="size-difference" class={diff().className}>

--- a/src/components/app/state/ImageAppContext.tsx
+++ b/src/components/app/state/ImageAppContext.tsx
@@ -129,7 +129,7 @@ export function ImageAppProvider(props: { children: JSX.Element }) {
     const sign = diff > 0 ? "+" : "";
     return {
       text: `Change: ${sign}${formatFileSize(Math.abs(diff))} (${sign}${pct}%)`,
-      className: diff > 0 ? "font-medium text-sp-coral" : "font-medium text-sp-mint-dark",
+      className: diff > 0 ? "font-medium text-coral-500" : "font-medium text-mint-600",
     };
   });
 

--- a/src/components/app/upload/UploadDropzone.tsx
+++ b/src/components/app/upload/UploadDropzone.tsx
@@ -51,7 +51,7 @@ export default function UploadDropzone(props: UploadDropzoneProps) {
             <line x1="5" y1="12" x2="19" y2="12" />
           </svg>
         </div>
-        <span class="text-[0.8rem] text-muted-foreground font-medium">Import image or drop</span>
+        <span class="text-xs text-muted-foreground font-medium">Import image or drop</span>
         {props.children}
       </div>
     </div>

--- a/src/components/app/upload/UploadDropzone.tsx
+++ b/src/components/app/upload/UploadDropzone.tsx
@@ -14,9 +14,9 @@ export default function UploadDropzone(props: UploadDropzoneProps) {
   return (
     <div
       id="upload-area"
-      class="bg-sp-bg-card border border-sp-border rounded-sp-lg px-4 py-5 text-center cursor-pointer transition-[border-color,box-shadow] duration-200 hover:border-sp-lavender hover:shadow-sp focus-visible:ring-2 focus-visible:ring-sp-lavender/40"
+      class="bg-card border border-border rounded-lg px-4 py-5 text-center cursor-pointer transition-[border-color,box-shadow] duration-200 hover:border-lavender-500 hover:shadow-sm focus-visible:ring-2 focus-visible:ring-lavender-500/40"
       style={{ "touch-action": "manipulation" }}
-      classList={{ "border-sp-lavender bg-sp-lavender-light": props.isDragOver }}
+      classList={{ "border-lavender-500 bg-lavender-50": props.isDragOver }}
       role="button"
       tabIndex={0}
       aria-label="Upload image or drag and drop"
@@ -38,7 +38,7 @@ export default function UploadDropzone(props: UploadDropzoneProps) {
       }}
     >
       <div class="flex flex-col items-center gap-2">
-        <div class="w-10 h-10 rounded-full border border-sp-border flex items-center justify-center text-sp-text-soft mb-1">
+        <div class="w-10 h-10 rounded-full border border-border flex items-center justify-center text-soft-foreground mb-1">
           <svg
             width="18"
             height="18"
@@ -51,7 +51,7 @@ export default function UploadDropzone(props: UploadDropzoneProps) {
             <line x1="5" y1="12" x2="19" y2="12" />
           </svg>
         </div>
-        <span class="text-[0.8rem] text-sp-text-muted font-medium">Import image or drop</span>
+        <span class="text-[0.8rem] text-muted-foreground font-medium">Import image or drop</span>
         {props.children}
       </div>
     </div>

--- a/src/components/app/upload/ValidationMessages.tsx
+++ b/src/components/app/upload/ValidationMessages.tsx
@@ -9,7 +9,7 @@ export default function ValidationMessages(props: ValidationMessagesProps) {
   return (
     <>
       <Show when={props.validation?.error}>
-        {(msg) => <div class="mt-2 text-sm text-sp-coral">{msg()}</div>}
+        {(msg) => <div class="mt-2 text-sm text-coral-500">{msg()}</div>}
       </Show>
       <Show when={!props.validation?.error && props.validation?.warning}>
         {(msg) => <div class="mt-2 text-sm text-[#d97706]">{msg()}</div>}

--- a/src/components/app/upload/ValidationMessages.tsx
+++ b/src/components/app/upload/ValidationMessages.tsx
@@ -12,7 +12,7 @@ export default function ValidationMessages(props: ValidationMessagesProps) {
         {(msg) => <div class="mt-2 text-sm text-coral-500">{msg()}</div>}
       </Show>
       <Show when={!props.validation?.error && props.validation?.warning}>
-        {(msg) => <div class="mt-2 text-sm text-[#d97706]">{msg()}</div>}
+        {(msg) => <div class="mt-2 text-sm text-yellow-600">{msg()}</div>}
       </Show>
     </>
   );

--- a/src/components/marketing/cards/AboutCard.astro
+++ b/src/components/marketing/cards/AboutCard.astro
@@ -1,4 +1,6 @@
 ---
+import Card from "../../ui/Card.astro";
+
 interface Props {
   children: unknown;
   delay?: number;
@@ -8,10 +10,6 @@ interface Props {
 const { delay = 0, class: className } = Astro.props;
 ---
 
-<div
-  class:list={["bg-sp-bg-card border border-sp-border rounded-sp-xl p-8 shadow-sp mb-6", className]}
-  data-reveal
-  data-reveal-delay={String(delay)}
->
+<Card variant="soft" class={["mb-6", className].filter(Boolean).join(" ")} delay={delay}>
   <slot />
-</div>
+</Card>

--- a/src/components/marketing/cards/PrivacyCard.astro
+++ b/src/components/marketing/cards/PrivacyCard.astro
@@ -1,7 +1,14 @@
 ---
+import Card from "../../ui/Card.astro";
 
+interface Props {
+  delay?: number;
+  class?: string;
+}
+
+const { delay = 0, class: className } = Astro.props;
 ---
 
-<div class="bg-sp-bg-card border border-sp-border rounded-sp-xl p-8 shadow-sp mb-6">
+<Card variant="soft" class={["mb-6", className].filter(Boolean).join(" ")} delay={delay}>
   <slot />
-</div>
+</Card>

--- a/src/components/marketing/cards/TechStackItem.astro
+++ b/src/components/marketing/cards/TechStackItem.astro
@@ -7,6 +7,6 @@ const { name, description } = Astro.props;
 ---
 
 <div class="bg-background border border-border-light rounded-md p-4 flex flex-col gap-1">
-  <span class="font-display font-semibold text-[0.95rem]">{name}</span>
-  <span class="text-[0.8rem] text-soft-foreground">{description}</span>
+  <span class="font-display font-semibold text-sm">{name}</span>
+  <span class="text-xs text-soft-foreground">{description}</span>
 </div>

--- a/src/components/marketing/cards/TechStackItem.astro
+++ b/src/components/marketing/cards/TechStackItem.astro
@@ -6,7 +6,7 @@ interface Props {
 const { name, description } = Astro.props;
 ---
 
-<div class="bg-sp-bg border border-sp-border-light rounded-sp p-4 flex flex-col gap-1">
+<div class="bg-background border border-border-light rounded-md p-4 flex flex-col gap-1">
   <span class="font-display font-semibold text-[0.95rem]">{name}</span>
-  <span class="text-[0.8rem] text-sp-text-soft">{description}</span>
+  <span class="text-[0.8rem] text-soft-foreground">{description}</span>
 </div>

--- a/src/components/marketing/hero/HeroCTA.astro
+++ b/src/components/marketing/hero/HeroCTA.astro
@@ -23,7 +23,7 @@ const {
     {label}
     <ArrowRight size={18} strokeWidth={2} class="cta-pop-arrow" />
   </ButtonLink>
-  {secondaryText ? <span class="text-[0.8rem] text-soft-foreground">{secondaryText}</span> : null}
+  {secondaryText ? <span class="text-xs text-soft-foreground">{secondaryText}</span> : null}
 </div>
 
 <style>

--- a/src/components/marketing/hero/HeroCTA.astro
+++ b/src/components/marketing/hero/HeroCTA.astro
@@ -23,7 +23,7 @@ const {
     {label}
     <ArrowRight size={18} strokeWidth={2} class="cta-pop-arrow" />
   </ButtonLink>
-  {secondaryText ? <span class="text-[0.8rem] text-sp-text-soft">{secondaryText}</span> : null}
+  {secondaryText ? <span class="text-[0.8rem] text-soft-foreground">{secondaryText}</span> : null}
 </div>
 
 <style>

--- a/src/components/marketing/hero/HeroSection.astro
+++ b/src/components/marketing/hero/HeroSection.astro
@@ -18,7 +18,7 @@ const variantClasses: Record<string, string> = {
   coral: "bg-coral-50 text-coral-600",
   mint: "bg-mint-50 text-mint-600",
   lavender: "bg-lavender-50 text-lavender-600",
-  yellow: "bg-yellow-50 text-[#a16207]",
+  yellow: "bg-yellow-50 text-yellow-700",
 };
 ---
 
@@ -70,7 +70,7 @@ const variantClasses: Record<string, string> = {
       subtitle ? (
         <p
           class:list={[
-            "text-[1.05rem] text-muted-foreground leading-[1.7] m-0 opacity-0 animate-hero-subtitle",
+            "text-lg text-muted-foreground leading-[1.7] m-0 opacity-0 animate-hero-subtitle",
             { "max-w-[520px] mx-auto": centered },
           ]}
         >

--- a/src/components/marketing/hero/HeroSection.astro
+++ b/src/components/marketing/hero/HeroSection.astro
@@ -15,10 +15,10 @@ interface Props {
 
 const { chip, chips, title, subtitle, gradientTitle, centered = true } = Astro.props;
 const variantClasses: Record<string, string> = {
-  coral: "bg-sp-coral-light text-sp-coral-dark",
-  mint: "bg-sp-mint-light text-sp-mint-dark",
-  lavender: "bg-sp-lavender-light text-sp-lavender-dark",
-  yellow: "bg-sp-yellow-light text-[#a16207]",
+  coral: "bg-coral-50 text-coral-600",
+  mint: "bg-mint-50 text-mint-600",
+  lavender: "bg-lavender-50 text-lavender-600",
+  yellow: "bg-yellow-50 text-[#a16207]",
 };
 ---
 
@@ -59,7 +59,7 @@ const variantClasses: Record<string, string> = {
         gradientTitle ? (
           <>
             <br />
-            <span class="bg-linear-to-br from-[var(--sp-coral)] to-[var(--sp-lavender-dark)] bg-clip-text text-transparent">
+            <span class="bg-linear-to-br from-[var(--coral-500)] to-[var(--lavender-600)] bg-clip-text text-transparent">
               {gradientTitle}
             </span>
           </>
@@ -70,7 +70,7 @@ const variantClasses: Record<string, string> = {
       subtitle ? (
         <p
           class:list={[
-            "text-[1.05rem] text-sp-text-muted leading-[1.7] m-0 opacity-0 animate-hero-subtitle",
+            "text-[1.05rem] text-muted-foreground leading-[1.7] m-0 opacity-0 animate-hero-subtitle",
             { "max-w-[520px] mx-auto": centered },
           ]}
         >

--- a/src/components/marketing/sections/BentoCard.astro
+++ b/src/components/marketing/sections/BentoCard.astro
@@ -1,4 +1,6 @@
 ---
+import Card from "../../ui/Card.astro";
+
 interface Props {
   color: "coral" | "mint" | "lavender" | "yellow";
   colSpan?: boolean;
@@ -11,27 +13,23 @@ interface Props {
 
 const { color, colSpan = false, delay = 0, icon: Icon, title, description } = Astro.props;
 const colorBg: Record<string, string> = {
-  coral: "bg-sp-coral-light border-[rgba(242,90,90,0.15)]",
-  mint: "bg-sp-mint-light border-[rgba(26,165,147,0.15)]",
-  lavender: "bg-sp-lavender-light border-[rgba(167,139,250,0.15)]",
-  yellow: "bg-sp-yellow-light border-[rgba(253,230,138,0.3)]",
+  coral: "bg-coral-50",
+  mint: "bg-mint-50",
+  lavender: "bg-lavender-50",
+  yellow: "bg-yellow-50",
 };
 ---
 
-<div
-  class:list={[
-    "bento-card group border border-transparent rounded-sp-xl p-8 transition-[transform,box-shadow] duration-300 shadow-sp hover:translate-y-[-4px] hover:shadow-sp-hover",
-    colorBg[color],
-    { "md:col-span-2": colSpan },
-  ]}
-  data-reveal
-  data-reveal-delay={String(delay)}
+<Card
+  variant="interactive"
+  class={["group", colorBg[color], colSpan && "md:col-span-2"].filter(Boolean).join(" ")}
+  delay={delay}
 >
   <div
     class="bento-card-content opacity-0 translate-y-7 scale-[0.98] transition-[opacity,transform] duration-[550ms] [transition-timing-function:cubic-bezier(0.22,1,0.36,1)] group-[&.revealed]:opacity-100 group-[&.revealed]:translate-y-0 group-[&.revealed]:scale-100"
   >
     <Icon size={32} strokeWidth={1.75} class="block mb-4 opacity-80" aria-hidden="true" />
     <h3 class="font-display text-[1.2rem] font-bold mb-2 mt-0">{title}</h3>
-    <p class="text-[0.9rem] text-sp-text-muted leading-[1.6] m-0">{description}</p>
+    <p class="text-[0.9rem] text-muted-foreground leading-[1.6] m-0">{description}</p>
   </div>
-</div>
+</Card>

--- a/src/components/marketing/sections/BentoCard.astro
+++ b/src/components/marketing/sections/BentoCard.astro
@@ -21,15 +21,22 @@ const colorBg: Record<string, string> = {
 ---
 
 <Card
-  variant="interactive"
-  class={["group", colorBg[color], colSpan && "md:col-span-2"].filter(Boolean).join(" ")}
+  variant="default"
+  class={[
+    "group",
+    colorBg[color],
+    "transition-shadow duration-300 hover:shadow-md",
+    colSpan && "md:col-span-2",
+  ]
+    .filter(Boolean)
+    .join(" ")}
   delay={delay}
 >
   <div
-    class="bento-card-content opacity-0 translate-y-7 scale-[0.98] transition-[opacity,transform] duration-[550ms] [transition-timing-function:cubic-bezier(0.22,1,0.36,1)] group-[&.revealed]:opacity-100 group-[&.revealed]:translate-y-0 group-[&.revealed]:scale-100"
+    class="bento-card-content opacity-0 translate-y-7 scale-[0.98] transition-[opacity,transform] duration-500 [transition-timing-function:cubic-bezier(0.22,1,0.36,1)] group-[&.revealed]:opacity-100 group-[&.revealed]:translate-y-0 group-[&.revealed]:scale-100"
   >
     <Icon size={32} strokeWidth={1.75} class="block mb-4 opacity-80" aria-hidden="true" />
-    <h3 class="font-display text-[1.2rem] font-bold mb-2 mt-0">{title}</h3>
-    <p class="text-[0.9rem] text-muted-foreground leading-[1.6] m-0">{description}</p>
+    <h3 class="font-display text-xl font-bold mb-2 mt-0">{title}</h3>
+    <p class="text-sm text-muted-foreground leading-relaxed m-0">{description}</p>
   </div>
 </Card>

--- a/src/components/marketing/sections/CTACard.astro
+++ b/src/components/marketing/sections/CTACard.astro
@@ -1,5 +1,6 @@
 ---
 import { ArrowRight } from "lucide-astro";
+import Card from "../../ui/Card.astro";
 import ButtonLink from "../../ui/ButtonLink.astro";
 import { makeHref } from "../../../lib/utils";
 import { ROUTES } from "../../../config/constants";
@@ -27,7 +28,7 @@ const {
   <div class="max-w-[500px] mx-auto">
     {
       background ? (
-        <div class="bg-sp-bg-card border border-sp-border rounded-sp-xl p-12 text-center shadow-sp">
+        <Card variant="default" class="!p-12 text-center">
           <h2
             class="font-display font-extrabold mb-4 tracking-tight cta-card-title"
             data-reveal
@@ -36,7 +37,7 @@ const {
             {title}
           </h2>
           <p
-            class="text-[1rem] text-sp-text-muted mb-8 leading-[1.6] m-0"
+            class="text-[1rem] text-muted-foreground mb-8 leading-[1.6] m-0"
             data-reveal
             data-reveal-delay="80"
           >
@@ -48,13 +49,13 @@ const {
               <ArrowRight size={18} strokeWidth={2} class="cta-pop-arrow" />
             </ButtonLink>
           </div>
-        </div>
+        </Card>
       ) : (
         <>
           <h2 class="font-display font-extrabold mb-4 tracking-tight opacity-0 cta-card-title animate-cta-title">
             {title}
           </h2>
-          <p class="text-[1rem] text-sp-text-muted mb-8 leading-[1.6] opacity-0 animate-cta-subtitle">
+          <p class="text-[1rem] text-muted-foreground mb-8 leading-[1.6] opacity-0 animate-cta-subtitle">
             {subtitle}
           </p>
           <ButtonLink href={ctaHref} size={size}>
@@ -75,6 +76,6 @@ const {
     animation: popBounceIn 0.6s 0.25s forwards;
   }
   .cta-card-title {
-    font-size: var(--sp-font-title);
+    font-size: var(--font-title);
   }
 </style>

--- a/src/components/marketing/sections/CTACard.astro
+++ b/src/components/marketing/sections/CTACard.astro
@@ -11,7 +11,6 @@ interface Props {
   ctaLabel?: string;
   ctaHref?: string;
   size?: "default" | "lg";
-  background?: boolean;
 }
 
 const {
@@ -20,61 +19,37 @@ const {
   ctaLabel = "Open Reshrimp",
   ctaHref = makeHref(ROUTES.APP),
   size = "lg",
-  background = false,
 } = Astro.props;
 ---
 
 <section class="px-8 py-20 text-center relative z-10">
   <div class="max-w-[500px] mx-auto">
-    {
-      background ? (
-        <Card variant="default" class="!p-12 text-center">
-          <h2
-            class="font-display font-extrabold mb-4 tracking-tight cta-card-title"
-            data-reveal
-            data-reveal-delay="0"
-          >
-            {title}
-          </h2>
-          <p
-            class="text-[1rem] text-muted-foreground mb-8 leading-[1.6] m-0"
-            data-reveal
-            data-reveal-delay="80"
-          >
-            {subtitle}
-          </p>
-          <div data-reveal data-reveal-delay="160">
-            <ButtonLink href={ctaHref} size={size}>
-              {ctaLabel}
-              <ArrowRight size={18} strokeWidth={2} class="cta-pop-arrow" />
-            </ButtonLink>
-          </div>
-        </Card>
-      ) : (
-        <>
-          <h2 class="font-display font-extrabold mb-4 tracking-tight opacity-0 cta-card-title animate-cta-title">
-            {title}
-          </h2>
-          <p class="text-[1rem] text-muted-foreground mb-8 leading-[1.6] opacity-0 animate-cta-subtitle">
-            {subtitle}
-          </p>
-          <ButtonLink href={ctaHref} size={size}>
-            {ctaLabel}
-            <ArrowRight size={18} strokeWidth={2} class="cta-pop-arrow" />
-          </ButtonLink>
-        </>
-      )
-    }
+    <Card variant="default" class="!p-12 text-center">
+      <h2
+        class="font-display font-extrabold mb-4 tracking-tight cta-card-title"
+        data-reveal
+        data-reveal-delay="0"
+      >
+        {title}
+      </h2>
+      <p
+        class="text-base text-muted-foreground mb-8 leading-relaxed m-0"
+        data-reveal
+        data-reveal-delay="80"
+      >
+        {subtitle}
+      </p>
+      <div data-reveal data-reveal-delay="160">
+        <ButtonLink href={ctaHref} size={size}>
+          {ctaLabel}
+          <ArrowRight size={18} strokeWidth={2} class="cta-pop-arrow" />
+        </ButtonLink>
+      </div>
+    </Card>
   </div>
 </section>
 
 <style>
-  .animate-cta-title {
-    animation: popBounceIn 0.6s 0.1s forwards;
-  }
-  .animate-cta-subtitle {
-    animation: popBounceIn 0.6s 0.25s forwards;
-  }
   .cta-card-title {
     font-size: var(--font-title);
   }

--- a/src/components/marketing/sections/FAQAccordion.astro
+++ b/src/components/marketing/sections/FAQAccordion.astro
@@ -14,7 +14,7 @@ const answerId = `faq-answer-${question
 
 <div class="faq-item group mb-3 overflow-hidden" data-reveal data-reveal-delay={String(delay)}>
   <button
-    class="faq-question w-full text-left font-display text-[1.05rem] font-semibold py-5 px-6 flex items-center justify-between gap-4 transition-colors duration-200 hover:text-sp-coral"
+    class="faq-question w-full text-left font-display text-[1.05rem] font-semibold py-5 px-6 flex items-center justify-between gap-4 transition-colors duration-200 hover:text-coral-500"
     aria-expanded="false"
     aria-controls={answerId}
     style="touch-action: manipulation"
@@ -24,7 +24,7 @@ const answerId = `faq-answer-${question
   <div class="faq-body" role="region" id={answerId}>
     <div class="overflow-hidden">
       <p
-        class="faq-answer text-[0.95rem] text-sp-text-muted leading-[1.7] px-6 pb-5 m-0"
+        class="faq-answer text-[0.95rem] text-muted-foreground leading-[1.7] px-6 pb-5 m-0"
         set:html={answer}
       />
     </div>
@@ -33,10 +33,10 @@ const answerId = `faq-answer-${question
 
 <style>
   .faq-item {
-    border: 1px solid var(--sp-border);
-    border-radius: var(--sp-radius);
-    background: var(--sp-bg-card);
-    box-shadow: var(--sp-shadow);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    background: var(--card);
+    box-shadow: var(--shadow-sm);
     transition:
       border-color 0.25s cubic-bezier(0.34, 1.56, 0.64, 1),
       box-shadow 0.25s cubic-bezier(0.34, 1.56, 0.64, 1),
@@ -47,7 +47,7 @@ const answerId = `faq-answer-${question
     content: "+";
     font-size: 1.3rem;
     font-weight: 400;
-    color: var(--sp-coral);
+    color: var(--coral-500);
     flex-shrink: 0;
     transition: transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
   }
@@ -87,13 +87,13 @@ const answerId = `faq-answer-${question
   }
 
   .faq-item.faq-open {
-    border-color: var(--sp-lavender);
-    box-shadow: var(--sp-shadow-glow);
+    border-color: var(--lavender-500);
+    box-shadow: var(--shadow-glow);
     transform: scale(1.008);
   }
 
   .faq-answer a {
-    color: var(--sp-coral);
+    color: var(--coral-500);
     text-decoration: underline;
     text-decoration-color: rgba(242, 90, 90, 0.3);
     text-underline-offset: 2px;
@@ -101,7 +101,7 @@ const answerId = `faq-answer-${question
   }
 
   .faq-answer a:hover {
-    text-decoration-color: var(--sp-coral);
+    text-decoration-color: var(--coral-500);
   }
 </style>
 

--- a/src/components/marketing/sections/FAQAccordion.astro
+++ b/src/components/marketing/sections/FAQAccordion.astro
@@ -14,7 +14,7 @@ const answerId = `faq-answer-${question
 
 <div class="faq-item group mb-3 overflow-hidden" data-reveal data-reveal-delay={String(delay)}>
   <button
-    class="faq-question w-full text-left font-display text-[1.05rem] font-semibold py-5 px-6 flex items-center justify-between gap-4 transition-colors duration-200 hover:text-coral-500"
+    class="faq-question w-full text-left font-display text-lg font-semibold py-5 px-6 flex items-center justify-between gap-4 transition-colors duration-200 hover:text-coral-500"
     aria-expanded="false"
     aria-controls={answerId}
     style="touch-action: manipulation"
@@ -24,7 +24,7 @@ const answerId = `faq-answer-${question
   <div class="faq-body" role="region" id={answerId}>
     <div class="overflow-hidden">
       <p
-        class="faq-answer text-[0.95rem] text-muted-foreground leading-[1.7] px-6 pb-5 m-0"
+        class="faq-answer text-sm text-muted-foreground leading-[1.7] px-6 pb-5 m-0"
         set:html={answer}
       />
     </div>

--- a/src/components/marketing/sections/FeatureSection.astro
+++ b/src/components/marketing/sections/FeatureSection.astro
@@ -19,7 +19,7 @@ const colorStroke: Record<string, string> = {
   coral: "text-coral-600",
   mint: "text-mint-600",
   lavender: "text-lavender-600",
-  yellow: "text-[#a16207]",
+  yellow: "text-yellow-700",
 };
 ---
 
@@ -40,7 +40,7 @@ const colorStroke: Record<string, string> = {
     <Icon size={40} strokeWidth={1.75} class={colorStroke[color]} />
   </div>
   <div class="flex-1">
-    <h2 class="font-display text-[1.35rem] font-bold mb-2 tracking-tight">{title}</h2>
-    <p class="text-[0.95rem] text-muted-foreground leading-[1.7] m-0">{description}</p>
+    <h2 class="font-display text-xl font-bold mb-2 tracking-tight">{title}</h2>
+    <p class="text-sm text-muted-foreground leading-[1.7] m-0">{description}</p>
   </div>
 </div>

--- a/src/components/marketing/sections/FeatureSection.astro
+++ b/src/components/marketing/sections/FeatureSection.astro
@@ -10,15 +10,15 @@ interface Props {
 
 const { icon: Icon, title, description, color, index } = Astro.props;
 const colorBg: Record<string, string> = {
-  coral: "bg-sp-coral-light",
-  mint: "bg-sp-mint-light",
-  lavender: "bg-sp-lavender-light",
-  yellow: "bg-sp-yellow-light",
+  coral: "bg-coral-50",
+  mint: "bg-mint-50",
+  lavender: "bg-lavender-50",
+  yellow: "bg-yellow-50",
 };
 const colorStroke: Record<string, string> = {
-  coral: "text-sp-coral-dark",
-  mint: "text-sp-mint-dark",
-  lavender: "text-sp-lavender-dark",
+  coral: "text-coral-600",
+  mint: "text-mint-600",
+  lavender: "text-lavender-600",
   yellow: "text-[#a16207]",
 };
 ---
@@ -33,7 +33,7 @@ const colorStroke: Record<string, string> = {
 >
   <div
     class:list={[
-      "shrink-0 w-[120px] h-[120px] rounded-sp-xl flex items-center justify-center shadow-sp max-sm:w-[100px] max-sm:h-[100px]",
+      "shrink-0 w-[120px] h-[120px] rounded-xl flex items-center justify-center shadow-sm max-sm:w-[100px] max-sm:h-[100px]",
       colorBg[color],
     ]}
   >
@@ -41,6 +41,6 @@ const colorStroke: Record<string, string> = {
   </div>
   <div class="flex-1">
     <h2 class="font-display text-[1.35rem] font-bold mb-2 tracking-tight">{title}</h2>
-    <p class="text-[0.95rem] text-sp-text-muted leading-[1.7] m-0">{description}</p>
+    <p class="text-[0.95rem] text-muted-foreground leading-[1.7] m-0">{description}</p>
   </div>
 </div>

--- a/src/components/marketing/sections/StepArrow.astro
+++ b/src/components/marketing/sections/StepArrow.astro
@@ -8,7 +8,7 @@ const { delay = 0 } = Astro.props;
 ---
 
 <div
-  class="text-soft-foreground pt-4 shrink-0 md:rotate-90 md:pt-0"
+  class="text-soft-foreground pt-4 shrink-0 rotate-90 md:rotate-0 md:px-4 md:pt-0"
   data-reveal
   data-reveal-delay={String(delay)}
 >

--- a/src/components/marketing/sections/StepArrow.astro
+++ b/src/components/marketing/sections/StepArrow.astro
@@ -8,7 +8,7 @@ const { delay = 0 } = Astro.props;
 ---
 
 <div
-  class="text-sp-text-soft pt-4 shrink-0 md:rotate-90 md:pt-0"
+  class="text-soft-foreground pt-4 shrink-0 md:rotate-90 md:pt-0"
   data-reveal
   data-reveal-delay={String(delay)}
 >

--- a/src/components/marketing/sections/StepItem.astro
+++ b/src/components/marketing/sections/StepItem.astro
@@ -9,9 +9,9 @@ interface Props {
 
 const { number, title, description, color, delay = 0 } = Astro.props;
 const colorBg: Record<string, string> = {
-  coral: "bg-sp-coral text-white",
-  mint: "bg-sp-mint text-white",
-  lavender: "bg-sp-lavender text-white",
+  coral: "bg-coral-500 text-white",
+  mint: "bg-mint-500 text-white",
+  lavender: "bg-lavender-500 text-white",
 };
 ---
 
@@ -25,5 +25,5 @@ const colorBg: Record<string, string> = {
     <span class="font-display text-[1.2rem] font-bold">{number}</span>
   </div>
   <h3 class="font-display text-[1.05rem] font-bold mb-1">{title}</h3>
-  <p class="text-[0.85rem] text-sp-text-muted leading-[1.6] m-0">{description}</p>
+  <p class="text-[0.85rem] text-muted-foreground leading-[1.6] m-0">{description}</p>
 </div>

--- a/src/components/marketing/sections/StepItem.astro
+++ b/src/components/marketing/sections/StepItem.astro
@@ -22,8 +22,8 @@ const colorBg: Record<string, string> = {
       colorBg[color],
     ]}
   >
-    <span class="font-display text-[1.2rem] font-bold">{number}</span>
+    <span class="font-display text-lg font-bold">{number}</span>
   </div>
-  <h3 class="font-display text-[1.05rem] font-bold mb-1">{title}</h3>
-  <p class="text-[0.85rem] text-muted-foreground leading-[1.6] m-0">{description}</p>
+  <h3 class="font-display text-lg font-bold mb-1">{title}</h3>
+  <p class="text-sm text-muted-foreground leading-relaxed m-0">{description}</p>
 </div>

--- a/src/components/marketing/sections/StepSection.astro
+++ b/src/components/marketing/sections/StepSection.astro
@@ -4,7 +4,7 @@
 
 <section class="px-8 py-16 relative z-10">
   <div class="max-w-[900px] mx-auto">
-    <div class="flex items-start justify-center gap-4 md:flex-col md:items-center">
+    <div class="flex flex-col items-center gap-4 md:flex-row md:items-start">
       <slot />
     </div>
   </div>

--- a/src/components/marketing/sections/TrustBanner.astro
+++ b/src/components/marketing/sections/TrustBanner.astro
@@ -4,40 +4,37 @@ import { ShieldCheck } from "lucide-astro";
 
 <section class="px-8 py-12 relative z-10">
   <div class="max-w-[700px] mx-auto">
-    <div
-      class="bg-sp-bg-card border border-sp-border rounded-sp-xl p-12 text-center shadow-sp"
-      data-reveal
-    >
-      <div class="text-sp-mint mb-5">
+    <div class="bg-card border border-border rounded-xl p-12 text-center shadow-sm" data-reveal>
+      <div class="text-mint-500 mb-5">
         <ShieldCheck size={36} strokeWidth={1.5} aria-hidden="true" />
       </div>
       <h2 class="font-display text-[1.5rem] font-bold mb-4 tracking-tight">
         Your images stay on your device. Period.
       </h2>
-      <p class="text-[0.9rem] text-sp-text-muted leading-[1.7] max-w-[500px] mx-auto mb-6">
+      <p class="text-[0.9rem] text-muted-foreground leading-[1.7] max-w-[500px] mx-auto mb-6">
         Reshrimp uses your browser's built-in APIs for all processing. After the first online visit,
         the app shell and core tools work offline. Background removal also works offline after its
         model assets are downloaded once. No uploads, accounts, or tracking.
       </p>
       <div class="flex justify-center flex-wrap gap-2">
         <span
-          class="inline-block text-[0.7rem] font-semibold py-[0.3rem] px-[0.8rem] rounded-sp-full bg-sp-mint-light text-sp-mint-dark tracking-[0.01em]"
+          class="inline-block text-[0.7rem] font-semibold py-[0.3rem] px-[0.8rem] rounded-full bg-mint-50 text-mint-600 tracking-[0.01em]"
           >No servers</span
         >
         <span
-          class="inline-block text-[0.7rem] font-semibold py-[0.3rem] px-[0.8rem] rounded-sp-full bg-sp-mint-light text-sp-mint-dark tracking-[0.01em]"
+          class="inline-block text-[0.7rem] font-semibold py-[0.3rem] px-[0.8rem] rounded-full bg-mint-50 text-mint-600 tracking-[0.01em]"
           >No cookies</span
         >
         <span
-          class="inline-block text-[0.7rem] font-semibold py-[0.3rem] px-[0.8rem] rounded-sp-full bg-sp-mint-light text-sp-mint-dark tracking-[0.01em]"
+          class="inline-block text-[0.7rem] font-semibold py-[0.3rem] px-[0.8rem] rounded-full bg-mint-50 text-mint-600 tracking-[0.01em]"
           >No analytics</span
         >
         <span
-          class="inline-block text-[0.7rem] font-semibold py-[0.3rem] px-[0.8rem] rounded-sp-full bg-sp-mint-light text-sp-mint-dark tracking-[0.01em]"
+          class="inline-block text-[0.7rem] font-semibold py-[0.3rem] px-[0.8rem] rounded-full bg-mint-50 text-mint-600 tracking-[0.01em]"
           >No accounts</span
         >
         <span
-          class="inline-block text-[0.7rem] font-semibold py-[0.3rem] px-[0.8rem] rounded-sp-full bg-sp-mint-light text-sp-mint-dark tracking-[0.01em]"
+          class="inline-block text-[0.7rem] font-semibold py-[0.3rem] px-[0.8rem] rounded-full bg-mint-50 text-mint-600 tracking-[0.01em]"
           >Open source</span
         >
       </div>

--- a/src/components/marketing/sections/TrustBanner.astro
+++ b/src/components/marketing/sections/TrustBanner.astro
@@ -8,33 +8,33 @@ import { ShieldCheck } from "lucide-astro";
       <div class="text-mint-500 mb-5">
         <ShieldCheck size={36} strokeWidth={1.5} aria-hidden="true" />
       </div>
-      <h2 class="font-display text-[1.5rem] font-bold mb-4 tracking-tight">
+      <h2 class="font-display text-2xl font-bold mb-4 tracking-tight">
         Your images stay on your device. Period.
       </h2>
-      <p class="text-[0.9rem] text-muted-foreground leading-[1.7] max-w-[500px] mx-auto mb-6">
+      <p class="text-sm text-muted-foreground leading-[1.7] max-w-[500px] mx-auto mb-6">
         Reshrimp uses your browser's built-in APIs for all processing. After the first online visit,
         the app shell and core tools work offline. Background removal also works offline after its
         model assets are downloaded once. No uploads, accounts, or tracking.
       </p>
       <div class="flex justify-center flex-wrap gap-2">
         <span
-          class="inline-block text-[0.7rem] font-semibold py-[0.3rem] px-[0.8rem] rounded-full bg-mint-50 text-mint-600 tracking-[0.01em]"
+          class="inline-block text-xs font-semibold py-[0.3rem] px-[0.8rem] rounded-full bg-mint-50 text-mint-600 tracking-[0.01em]"
           >No servers</span
         >
         <span
-          class="inline-block text-[0.7rem] font-semibold py-[0.3rem] px-[0.8rem] rounded-full bg-mint-50 text-mint-600 tracking-[0.01em]"
+          class="inline-block text-xs font-semibold py-[0.3rem] px-[0.8rem] rounded-full bg-mint-50 text-mint-600 tracking-[0.01em]"
           >No cookies</span
         >
         <span
-          class="inline-block text-[0.7rem] font-semibold py-[0.3rem] px-[0.8rem] rounded-full bg-mint-50 text-mint-600 tracking-[0.01em]"
+          class="inline-block text-xs font-semibold py-[0.3rem] px-[0.8rem] rounded-full bg-mint-50 text-mint-600 tracking-[0.01em]"
           >No analytics</span
         >
         <span
-          class="inline-block text-[0.7rem] font-semibold py-[0.3rem] px-[0.8rem] rounded-full bg-mint-50 text-mint-600 tracking-[0.01em]"
+          class="inline-block text-xs font-semibold py-[0.3rem] px-[0.8rem] rounded-full bg-mint-50 text-mint-600 tracking-[0.01em]"
           >No accounts</span
         >
         <span
-          class="inline-block text-[0.7rem] font-semibold py-[0.3rem] px-[0.8rem] rounded-full bg-mint-50 text-mint-600 tracking-[0.01em]"
+          class="inline-block text-xs font-semibold py-[0.3rem] px-[0.8rem] rounded-full bg-mint-50 text-mint-600 tracking-[0.01em]"
           >Open source</span
         >
       </div>

--- a/src/components/shared/FloatingShapes.astro
+++ b/src/components/shared/FloatingShapes.astro
@@ -29,7 +29,7 @@
   .shape-1 {
     width: 200px;
     height: 200px;
-    background: var(--sp-coral-light);
+    background: var(--coral-50);
     top: 10%;
     right: 5%;
     border-radius: 30% 70% 70% 30% / 30% 30% 70% 70%;
@@ -39,7 +39,7 @@
   .shape-2 {
     width: 150px;
     height: 150px;
-    background: var(--sp-mint-light);
+    background: var(--mint-50);
     top: 60%;
     left: 3%;
     border-radius: 60% 40% 30% 70% / 60% 30% 70% 40%;
@@ -49,7 +49,7 @@
   .shape-3 {
     width: 100px;
     height: 100px;
-    background: var(--sp-lavender-light);
+    background: var(--lavender-50);
     top: 30%;
     left: 15%;
     border-radius: 40% 60% 60% 40% / 70% 30% 70% 30%;
@@ -59,7 +59,7 @@
   .shape-4 {
     width: 180px;
     height: 180px;
-    background: var(--sp-yellow-light);
+    background: var(--yellow-50);
     bottom: 15%;
     right: 10%;
     border-radius: 70% 30% 50% 50% / 30% 50% 50% 70%;
@@ -69,7 +69,7 @@
   .shape-5 {
     width: 120px;
     height: 120px;
-    background: var(--sp-border-light);
+    background: var(--border-light);
     top: 75%;
     left: 45%;
     border-radius: 50% 50% 30% 70% / 60% 40% 60% 40%;

--- a/src/components/shared/Logo.astro
+++ b/src/components/shared/Logo.astro
@@ -4,38 +4,38 @@ import { makeHref } from "../../lib/utils";
 import { SITE_NAME } from "../../config/constants";
 ---
 
-<a href={makeHref(href)} class="sp-logo-wrapper">
-  <span class="sp-logo-dot"></span>
+<a href={makeHref(href)} class="logo-wrapper">
+  <span class="logo-dot"></span>
   {SITE_NAME.toLowerCase()}
 </a>
 
 <style>
-  .sp-logo-wrapper {
+  .logo-wrapper {
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    font-family: var(--sp-font-display);
+    font-family: var(--font-display);
     font-size: 1.2rem;
     font-weight: 700;
-    color: var(--sp-text);
+    color: var(--foreground);
     text-decoration: none;
     transition: opacity 0.2s;
   }
 
-  .sp-logo-wrapper:hover {
+  .logo-wrapper:hover {
     opacity: 0.8;
   }
 
-  .sp-logo-dot {
+  .logo-dot {
     width: 10px;
     height: 10px;
     border-radius: 50%;
-    background: var(--sp-coral);
+    background: var(--coral-500);
     flex-shrink: 0;
     transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
   }
 
-  .sp-logo-wrapper:hover .sp-logo-dot {
+  .logo-wrapper:hover .logo-dot {
     transform: scale(1.4);
   }
 </style>

--- a/src/components/shared/MarketingFooter.astro
+++ b/src/components/shared/MarketingFooter.astro
@@ -10,35 +10,35 @@ const footerLinks = [
 ];
 ---
 
-<footer class="sp-footer">
-  <div class="sp-footer-inner">
-    <nav class="sp-footer-links" aria-label="Footer navigation">
+<footer class="footer">
+  <div class="footer-inner">
+    <nav class="footer-links" aria-label="Footer navigation">
       {
         footerLinks.map((link) => (
-          <a href={makeHref(link.path)} class="sp-footer-link">
+          <a href={makeHref(link.path)} class="footer-link">
             {link.label}
           </a>
         ))
       }
     </nav>
-    <div class="sp-footer-bottom">
+    <div class="footer-bottom">
       <span>&copy; {new Date().getFullYear()} {SITE_NAME}</span>
-      <span class="sp-footer-dot">&middot;</span>
+      <span class="footer-dot">&middot;</span>
       <span>Processed locally in your browser</span>
     </div>
   </div>
 </footer>
 
 <style>
-  .sp-footer {
-    border-top: 1px solid var(--sp-border-light);
+  .footer {
+    border-top: 1px solid var(--border-light);
     padding: 2rem;
     position: relative;
     z-index: 1;
   }
 
-  .sp-footer-inner {
-    max-width: var(--sp-content-max-width);
+  .footer-inner {
+    max-width: var(--content-max-width);
     margin: 0 auto;
     display: flex;
     flex-direction: column;
@@ -46,40 +46,40 @@ const footerLinks = [
     gap: 1rem;
   }
 
-  .sp-footer-links {
+  .footer-links {
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
     gap: 0.5rem 1.5rem;
   }
 
-  .sp-footer-link {
+  .footer-link {
     font-size: 0.85rem;
     font-weight: 500;
-    color: var(--sp-text-muted);
+    color: var(--muted-foreground);
     text-decoration: none;
     transition: color 0.2s;
   }
 
-  .sp-footer-link:hover {
-    color: var(--sp-coral);
+  .footer-link:hover {
+    color: var(--coral-500);
   }
 
-  .sp-footer-link:focus-visible {
+  .footer-link:focus-visible {
     outline: none;
     box-shadow: 0 0 0 2px rgba(167, 139, 250, 0.4);
     border-radius: 4px;
   }
 
-  .sp-footer-bottom {
+  .footer-bottom {
     display: flex;
     align-items: center;
     gap: 0.75rem;
     font-size: 0.8rem;
-    color: var(--sp-text-soft);
+    color: var(--soft-foreground);
   }
 
-  .sp-footer-dot {
-    color: var(--sp-border);
+  .footer-dot {
+    color: var(--border);
   }
 </style>

--- a/src/components/shared/MarketingHeader.astro
+++ b/src/components/shared/MarketingHeader.astro
@@ -15,16 +15,16 @@ const headerLinks = [
 ];
 ---
 
-<header class="sp-header" id="sp-header" transition:animate="none">
-  <nav class="sp-header-inner">
+<header class="header" id="header" transition:animate="none">
+  <nav class="header-inner">
     <Logo />
 
-    <div class="sp-nav-desktop">
+    <div class="nav-desktop">
       {
         headerLinks.map((link) => (
           <a
             href={makeHref(link.href)}
-            class:list={["sp-nav-link", { "sp-nav-link-active": currentPath === link.href }]}
+            class:list={["nav-link", { "nav-link-active": currentPath === link.href }]}
           >
             {link.label}
           </a>
@@ -34,7 +34,7 @@ const headerLinks = [
         href={GITHUB_URL}
         target="_blank"
         rel="noopener noreferrer"
-        class="sp-nav-link sp-nav-github"
+        class="nav-link nav-github"
         aria-label="View on GitHub"
       >
         <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
@@ -47,14 +47,14 @@ const headerLinks = [
 
     <button
       type="button"
-      class="sp-hamburger"
+      class="hamburger"
       id="mobile-menu-btn"
       aria-label="Toggle menu"
       aria-expanded="false"
       aria-controls="mobile-menu-panel"
     >
       <svg
-        class="sp-hamburger-icon"
+        class="hamburger-icon"
         width="24"
         height="24"
         viewBox="0 0 24 24"
@@ -70,19 +70,19 @@ const headerLinks = [
     </button>
   </nav>
 
-  <div class="sp-mobile-panel" id="mobile-menu-panel">
-    <div class="sp-mobile-panel-inner">
+  <div class="mobile-panel" id="mobile-menu-panel">
+    <div class="mobile-panel-inner">
       {
         headerLinks.map((link) => (
           <a
             href={makeHref(link.href)}
-            class:list={["sp-mobile-link", { "sp-mobile-link-active": currentPath === link.href }]}
+            class:list={["mobile-link", { "mobile-link-active": currentPath === link.href }]}
           >
             {link.label}
           </a>
         ))
       }
-      <a href={GITHUB_URL} target="_blank" rel="noopener noreferrer" class="sp-mobile-link">
+      <a href={GITHUB_URL} target="_blank" rel="noopener noreferrer" class="mobile-link">
         GitHub
       </a>
     </div>
@@ -90,25 +90,25 @@ const headerLinks = [
 </header>
 
 <style>
-  .sp-header {
+  .header {
     position: sticky;
     top: 0;
     z-index: 100;
     background: rgba(248, 247, 255, 0.85);
     backdrop-filter: blur(16px);
-    border-bottom: 1px solid var(--sp-border-light);
+    border-bottom: 1px solid var(--border-light);
     transition:
       box-shadow 0.3s ease,
       border-bottom-color 0.3s ease;
   }
 
-  .sp-header.scrolled {
+  .header.scrolled {
     box-shadow: 0 2px 20px rgba(30, 27, 75, 0.08);
-    border-bottom-color: var(--sp-border);
+    border-bottom-color: var(--border);
   }
 
-  .sp-header-inner {
-    max-width: var(--sp-content-max-width);
+  .header-inner {
+    max-width: var(--content-max-width);
     margin: 0 auto;
     display: flex;
     justify-content: space-between;
@@ -116,42 +116,42 @@ const headerLinks = [
     padding: 0.85rem 2rem;
   }
 
-  .sp-nav-desktop {
+  .nav-desktop {
     display: flex;
     align-items: center;
     gap: 0.5rem;
   }
 
-  .sp-nav-link {
+  .nav-link {
     font-size: 0.85rem;
     font-weight: 500;
-    color: var(--sp-text-muted);
+    color: var(--muted-foreground);
     text-decoration: none;
     padding: 0.45rem 0.85rem;
-    border-radius: var(--sp-radius-full);
+    border-radius: var(--radius-full);
     transition:
       color 0.2s ease,
       background 0.2s ease;
     position: relative;
   }
 
-  .sp-nav-link:hover {
-    color: var(--sp-text);
-    background: var(--sp-border-light);
+  .nav-link:hover {
+    color: var(--foreground);
+    background: var(--border-light);
   }
 
-  .sp-nav-link:focus-visible {
+  .nav-link:focus-visible {
     outline: none;
     box-shadow: 0 0 0 2px rgba(167, 139, 250, 0.4);
   }
 
-  .sp-nav-link-active {
-    color: var(--sp-text);
+  .nav-link-active {
+    color: var(--foreground);
     font-weight: 600;
-    background: var(--sp-border-light);
+    background: var(--border-light);
   }
 
-  .sp-nav-link-active::after {
+  .nav-link-active::after {
     content: "";
     position: absolute;
     bottom: 4px;
@@ -159,20 +159,20 @@ const headerLinks = [
     transform: translateX(-50%);
     width: 16px;
     height: 2px;
-    background: var(--sp-coral);
+    background: var(--coral-500);
     border-radius: 2px;
   }
 
-  .sp-nav-github {
+  .nav-github {
     display: flex;
     align-items: center;
     padding: 0.45rem;
   }
 
-  .sp-hamburger {
+  .hamburger {
     display: none;
     cursor: pointer;
-    color: var(--sp-text);
+    color: var(--foreground);
     background: none;
     border: none;
     padding: 0.25rem;
@@ -187,20 +187,20 @@ const headerLinks = [
     transform-origin: center;
   }
 
-  .sp-hamburger[aria-expanded="true"] .ham-line-1 {
+  .hamburger[aria-expanded="true"] .ham-line-1 {
     transform: translateY(6px) rotate(45deg);
   }
 
-  .sp-hamburger[aria-expanded="true"] .ham-line-2 {
+  .hamburger[aria-expanded="true"] .ham-line-2 {
     opacity: 0;
     transform: scaleX(0);
   }
 
-  .sp-hamburger[aria-expanded="true"] .ham-line-3 {
+  .hamburger[aria-expanded="true"] .ham-line-3 {
     transform: translateY(-6px) rotate(-45deg);
   }
 
-  .sp-mobile-panel {
+  .mobile-panel {
     max-height: 0;
     overflow: hidden;
     transition:
@@ -209,49 +209,49 @@ const headerLinks = [
     border-bottom: 1px solid transparent;
   }
 
-  .sp-mobile-panel.sp-mobile-open {
+  .mobile-panel.mobile-open {
     max-height: 400px;
-    border-bottom-color: var(--sp-border-light);
+    border-bottom-color: var(--border-light);
   }
 
-  .sp-mobile-panel-inner {
+  .mobile-panel-inner {
     display: flex;
     flex-direction: column;
     gap: 0.25rem;
     padding: 0.5rem 2rem 1.5rem;
   }
 
-  .sp-mobile-link {
+  .mobile-link {
     font-size: 0.95rem;
     font-weight: 500;
-    color: var(--sp-text-muted);
+    color: var(--muted-foreground);
     text-decoration: none;
     padding: 0.6rem 0;
     transition: color 0.2s;
     border-bottom: 1px solid transparent;
   }
 
-  .sp-mobile-link:hover {
-    color: var(--sp-text);
+  .mobile-link:hover {
+    color: var(--foreground);
   }
 
-  .sp-mobile-link:focus-visible {
+  .mobile-link:focus-visible {
     outline: none;
     box-shadow: 0 0 0 2px rgba(167, 139, 250, 0.4);
     border-radius: 4px;
   }
 
-  .sp-mobile-link-active {
-    color: var(--sp-coral);
+  .mobile-link-active {
+    color: var(--coral-500);
     font-weight: 600;
   }
 
   @media (max-width: 768px) {
-    .sp-nav-desktop {
+    .nav-desktop {
       display: none;
     }
 
-    .sp-hamburger {
+    .hamburger {
       display: flex;
       align-items: center;
       justify-content: center;
@@ -260,12 +260,12 @@ const headerLinks = [
       border: none;
       background: none;
       cursor: pointer;
-      border-radius: var(--sp-radius);
+      border-radius: var(--radius-md);
       padding: 4px;
-      color: var(--sp-text);
+      color: var(--foreground);
     }
 
-    .sp-hamburger:focus-visible {
+    .hamburger:focus-visible {
       outline: none;
       box-shadow: 0 0 0 2px rgba(167, 139, 250, 0.4);
     }
@@ -281,12 +281,12 @@ const headerLinks = [
     if (!btn || !panel) return;
 
     const closeMenu = () => {
-      panel.classList.remove("sp-mobile-open");
+      panel.classList.remove("mobile-open");
       btn.setAttribute("aria-expanded", "false");
     };
 
     const toggleMenu = () => {
-      const open = panel.classList.toggle("sp-mobile-open");
+      const open = panel.classList.toggle("mobile-open");
       btn.setAttribute("aria-expanded", String(open));
     };
 
@@ -300,7 +300,7 @@ const headerLinks = [
   }
 
   function initHeaderScroll(isSpaNavigation: boolean) {
-    const header = document.getElementById("sp-header");
+    const header = document.getElementById("header");
     if (!header) return;
 
     const update = () => {

--- a/src/components/shared/MarketingSectionHeader.astro
+++ b/src/components/shared/MarketingSectionHeader.astro
@@ -7,9 +7,8 @@ interface Props {
 const { label, title } = Astro.props;
 ---
 
-<div class="sp-section-header text-center">
-  <span
-    class="block text-[0.8rem] font-semibold text-sp-lavender-dark uppercase tracking-[0.08em] mb-2"
+<div class="section-header text-center">
+  <span class="block text-[0.8rem] font-semibold text-lavender-600 uppercase tracking-[0.08em] mb-2"
     >{label}</span
   >
   <h2

--- a/src/components/shared/MarketingSectionHeader.astro
+++ b/src/components/shared/MarketingSectionHeader.astro
@@ -8,7 +8,7 @@ const { label, title } = Astro.props;
 ---
 
 <div class="section-header text-center">
-  <span class="block text-[0.8rem] font-semibold text-lavender-600 uppercase tracking-[0.08em] mb-2"
+  <span class="block text-xs font-semibold text-lavender-600 uppercase tracking-[0.08em] mb-2"
     >{label}</span
   >
   <h2

--- a/src/components/ui/Card.astro
+++ b/src/components/ui/Card.astro
@@ -1,0 +1,28 @@
+---
+interface Props {
+  variant?: "default" | "interactive" | "primary" | "soft" | "outline";
+  class?: string;
+  delay?: number;
+}
+
+const { variant = "default", class: className, delay = 0 } = Astro.props;
+
+const variantClasses: Record<string, string> = {
+  default: "bg-card border border-border rounded-xl p-8 shadow-sm",
+  interactive:
+    "bg-card border border-border rounded-xl p-8 shadow-sm transition-[transform,box-shadow] duration-300 hover:translate-y-[-4px] hover:shadow-md cursor-pointer",
+  primary: "bg-coral-50 border border-coral-200 rounded-xl p-8 shadow-sm",
+  soft: "bg-card border border-border rounded-xl p-8 shadow-sm",
+  outline: "bg-transparent border border-border rounded-xl p-8",
+};
+---
+
+<div
+  class:list={[variantClasses[variant], className]}
+  data-reveal
+  data-reveal-delay={String(delay)}
+>
+  <slot name="header" />
+  <slot />
+  <slot name="footer" />
+</div>

--- a/src/components/ui/Checkbox.tsx
+++ b/src/components/ui/Checkbox.tsx
@@ -9,7 +9,7 @@ interface CheckboxProps {
 export default function Checkbox(props: CheckboxProps) {
   return (
     <label
-      class="flex items-center gap-2 text-[0.85rem] text-sp-text cursor-pointer select-none"
+      class="flex items-center gap-2 text-[0.85rem] text-foreground cursor-pointer select-none"
       classList={{ "opacity-40 cursor-not-allowed": props.disabled }}
     >
       <span class="relative flex items-center justify-center w-[18px] h-[18px] shrink-0">
@@ -23,10 +23,10 @@ export default function Checkbox(props: CheckboxProps) {
           style={{ "touch-action": "manipulation" }}
         />
         <span
-          class="absolute inset-0 rounded-[5px] border-[1.5px] transition-[background-color,border-color] duration-200 pointer-events-none focus-within:ring-2 focus-within:ring-sp-lavender focus-within:ring-offset-2"
+          class="absolute inset-0 rounded-sm border-[1.5px] transition-[background-color,border-color] duration-200 pointer-events-none focus-within:ring-2 focus-within:ring-lavender-500 focus-within:ring-offset-2"
           classList={{
-            "bg-sp-lavender border-sp-lavender": props.checked,
-            "bg-white border-sp-border": !props.checked,
+            "bg-lavender-500 border-lavender-500": props.checked,
+            "bg-white border-border": !props.checked,
           }}
         >
           <svg

--- a/src/components/ui/Checkbox.tsx
+++ b/src/components/ui/Checkbox.tsx
@@ -9,7 +9,7 @@ interface CheckboxProps {
 export default function Checkbox(props: CheckboxProps) {
   return (
     <label
-      class="flex items-center gap-2 text-[0.85rem] text-foreground cursor-pointer select-none"
+      class="flex items-center gap-2 text-sm text-foreground cursor-pointer select-none"
       classList={{ "opacity-40 cursor-not-allowed": props.disabled }}
     >
       <span class="relative flex items-center justify-center w-[18px] h-[18px] shrink-0">

--- a/src/components/ui/Field.tsx
+++ b/src/components/ui/Field.tsx
@@ -10,7 +10,7 @@ export default function Field(props: FieldProps) {
   return (
     <div>
       <div class="flex items-center gap-1.5 mb-1">
-        <span class="text-[0.8rem] text-muted-foreground">{props.label}</span>
+        <span class="text-xs text-muted-foreground">{props.label}</span>
         {props.labelAccessory}
       </div>
       {props.children}

--- a/src/components/ui/Field.tsx
+++ b/src/components/ui/Field.tsx
@@ -10,7 +10,7 @@ export default function Field(props: FieldProps) {
   return (
     <div>
       <div class="flex items-center gap-1.5 mb-1">
-        <span class="text-[0.8rem] text-sp-text-muted">{props.label}</span>
+        <span class="text-[0.8rem] text-muted-foreground">{props.label}</span>
         {props.labelAccessory}
       </div>
       {props.children}

--- a/src/components/ui/InfoTooltip.tsx
+++ b/src/components/ui/InfoTooltip.tsx
@@ -79,7 +79,7 @@ export default function InfoTooltip(props: InfoTooltipProps) {
       <button
         id={props.id ? `${props.id}-icon` : undefined}
         type="button"
-        class="inline-flex items-center justify-center w-5 h-5 p-0 text-sp-text-muted bg-transparent border-none rounded-full cursor-pointer transition-colors duration-200 hover:text-sp-lavender focus-visible:outline-2 focus-visible:outline-sp-lavender focus-visible:outline-offset-2"
+        class="inline-flex items-center justify-center w-5 h-5 p-0 text-muted-foreground bg-transparent border-none rounded-full cursor-pointer transition-colors duration-200 hover:text-lavender-500 focus-visible:outline-2 focus-visible:outline-lavender-500 focus-visible:outline-offset-2"
         aria-label={props.ariaLabel}
         ref={setTriggerEl}
         onFocus={handleEnter}
@@ -95,7 +95,7 @@ export default function InfoTooltip(props: InfoTooltipProps) {
         <Portal>
           <span
             id={props.id ? `${props.id}-tooltip` : undefined}
-            class="info-tooltip active info-tooltip-portaled text-[0.75rem] leading-[1.4] text-sp-text"
+            class="info-tooltip active info-tooltip-portaled text-[0.75rem] leading-[1.4] text-foreground"
             role="tooltip"
             style={{
               bottom: `${pos().bottom}px`,

--- a/src/components/ui/InfoTooltip.tsx
+++ b/src/components/ui/InfoTooltip.tsx
@@ -95,7 +95,7 @@ export default function InfoTooltip(props: InfoTooltipProps) {
         <Portal>
           <span
             id={props.id ? `${props.id}-tooltip` : undefined}
-            class="info-tooltip active info-tooltip-portaled text-[0.75rem] leading-[1.4] text-foreground"
+            class="info-tooltip active info-tooltip-portaled text-xs leading-[1.4] text-foreground"
             role="tooltip"
             style={{
               bottom: `${pos().bottom}px`,

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -19,11 +19,11 @@ export { errorClasses, successClasses };
 export default function Input(props: InputProps) {
   return (
     <label class="block">
-      <span class="block text-[0.75rem] text-muted-foreground mb-1 font-medium">{props.label}</span>
+      <span class="block text-xs text-muted-foreground mb-1 font-medium">{props.label}</span>
       <input
         id={props.id}
         type={props.type ?? "number"}
-        class="w-full px-3 py-2.5 border border-border rounded-lg font-body text-[0.85rem] text-foreground bg-background transition-[border-color,box-shadow] duration-200 focus-visible:outline-hidden focus-visible:border-lavender-500 focus-visible:ring-2 focus-visible:ring-ring"
+        class="w-full px-3 py-2.5 border border-border rounded-lg font-body text-sm text-foreground bg-background transition-[border-color,box-shadow] duration-200 focus-visible:outline-hidden focus-visible:border-lavender-500 focus-visible:ring-2 focus-visible:ring-ring"
         min={props.min ?? "0.001"}
         max={props.max ?? "100000"}
         step={props.step ?? "any"}

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -11,14 +11,19 @@ interface InputProps {
   step?: number | string;
 }
 
+const errorClasses = "border-coral-300 bg-coral-50 focus-visible:ring-coral-500/40";
+const successClasses = "border-mint-300 bg-mint-50 focus-visible:ring-mint-500/40";
+
+export { errorClasses, successClasses };
+
 export default function Input(props: InputProps) {
   return (
     <label class="block">
-      <span class="block text-[0.75rem] text-sp-text-muted mb-1 font-medium">{props.label}</span>
+      <span class="block text-[0.75rem] text-muted-foreground mb-1 font-medium">{props.label}</span>
       <input
         id={props.id}
         type={props.type ?? "number"}
-        class="w-full px-3 py-2.5 border border-sp-border rounded-sp-lg font-body text-[0.85rem] text-sp-text bg-sp-bg transition-[border-color,box-shadow] duration-200 focus-visible:outline-hidden focus-visible:border-sp-lavender focus-visible:ring-2 focus-visible:ring-sp-lavender/40"
+        class="w-full px-3 py-2.5 border border-border rounded-lg font-body text-[0.85rem] text-foreground bg-background transition-[border-color,box-shadow] duration-200 focus-visible:outline-hidden focus-visible:border-lavender-500 focus-visible:ring-2 focus-visible:ring-ring"
         min={props.min ?? "0.001"}
         max={props.max ?? "100000"}
         step={props.step ?? "any"}

--- a/src/components/ui/SectionHeader.tsx
+++ b/src/components/ui/SectionHeader.tsx
@@ -6,7 +6,7 @@ interface SectionHeaderProps {
 
 export default function SectionHeader(props: SectionHeaderProps) {
   return (
-    <h4 class="text-[0.7rem] font-semibold text-sp-text-muted m-0 uppercase tracking-[0.12em]">
+    <h4 class="text-[0.7rem] font-semibold text-muted-foreground m-0 uppercase tracking-[0.12em]">
       {props.children}
     </h4>
   );

--- a/src/components/ui/SectionHeader.tsx
+++ b/src/components/ui/SectionHeader.tsx
@@ -6,7 +6,7 @@ interface SectionHeaderProps {
 
 export default function SectionHeader(props: SectionHeaderProps) {
   return (
-    <h4 class="text-[0.7rem] font-semibold text-muted-foreground m-0 uppercase tracking-[0.12em]">
+    <h4 class="text-xs font-semibold text-muted-foreground m-0 uppercase tracking-[0.12em]">
       {props.children}
     </h4>
   );

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -201,15 +201,15 @@ export default function Select(props: SelectProps) {
         aria-controls={open() ? listboxId : undefined}
         aria-disabled={props.disabled}
         disabled={props.disabled}
-        class={`flex w-full items-center justify-between gap-2 px-3 py-2 border border-sp-border rounded-sp font-body text-[0.85rem] text-sp-text bg-sp-bg cursor-pointer text-left transition-[border-color,box-shadow] duration-200 hover:border-sp-lavender hover:bg-sp-lavender-light focus-visible:outline-hidden focus-visible:border-sp-lavender focus-visible:shadow-[0_0_0_3px_rgba(167,139,250,0.15)] disabled:opacity-50 disabled:cursor-not-allowed${props.class ? ` ${props.class}` : ""}`}
-        classList={{ "sp-select-trigger-open": open() }}
+        class={`flex w-full items-center justify-between gap-2 px-3 py-2 border border-border rounded-md font-body text-[0.85rem] text-foreground bg-background cursor-pointer text-left transition-[border-color,box-shadow] duration-200 hover:border-lavender-500 hover:bg-lavender-50 focus-visible:outline-hidden focus-visible:border-lavender-500 focus-visible:shadow-[0_0_0_3px_rgba(167,139,250,0.15)] disabled:opacity-50 disabled:cursor-not-allowed${props.class ? ` ${props.class}` : ""}`}
+        classList={{ "select-trigger-open": open() }}
         onClick={() => (open() ? closeDropdown() : openDropdown())}
         onKeyDown={handleTriggerKeyDown}
       >
-        <span class="flex-1 truncate text-sp-text">{selectedLabel()}</span>
+        <span class="flex-1 truncate text-foreground">{selectedLabel()}</span>
         <svg
-          class="shrink-0 text-sp-lavender transition-transform duration-200 sp-select-chevron"
-          classList={{ "sp-select-chevron-open": open() }}
+          class="shrink-0 text-lavender-500 transition-transform duration-200 select-chevron"
+          classList={{ "select-chevron-open": open() }}
           width="12"
           height="12"
           viewBox="0 0 12 12"
@@ -235,8 +235,8 @@ export default function Select(props: SelectProps) {
             role="listbox"
             aria-labelledby={props.id ?? triggerId}
             tabIndex={-1}
-            class="sp-select-listbox sp-select-listbox-portaled"
-            classList={{ "sp-select-listbox-upward": pos().openUpward }}
+            class="select-listbox select-listbox-portaled"
+            classList={{ "select-listbox-upward": pos().openUpward }}
             style={{
               top: pos().top !== undefined ? `${pos().top}px` : "auto",
               bottom: pos().bottom !== undefined ? `${pos().bottom}px` : "auto",
@@ -252,11 +252,11 @@ export default function Select(props: SelectProps) {
                   role="option"
                   aria-selected={option.value === props.value}
                   aria-disabled={option.disabled}
-                  class="flex items-center justify-between px-2.5 py-[0.45rem] rounded-sp-sm font-body text-[0.85rem] text-sp-text cursor-pointer select-none transition-[background] duration-100 sp-select-option"
+                  class="flex items-center justify-between px-2.5 py-[0.45rem] rounded-sm font-body text-[0.85rem] text-foreground cursor-pointer select-none transition-[background] duration-100 select-option"
                   classList={{
-                    "sp-select-option-selected": option.value === props.value,
-                    "sp-select-option-focused": index() === focusedIndex(),
-                    "sp-select-option-disabled": !!option.disabled,
+                    "select-option-selected": option.value === props.value,
+                    "select-option-focused": index() === focusedIndex(),
+                    "select-option-disabled": !!option.disabled,
                   }}
                   onMouseEnter={() => !option.disabled && setFocusedIndex(index())}
                   onMouseDown={(e) => {
@@ -267,7 +267,7 @@ export default function Select(props: SelectProps) {
                   {option.label}
                   <Show when={option.value === props.value}>
                     <svg
-                      class="shrink-0 text-sp-lavender-dark sp-select-check"
+                      class="shrink-0 text-lavender-600 select-check"
                       width="12"
                       height="12"
                       viewBox="0 0 12 12"

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -201,7 +201,7 @@ export default function Select(props: SelectProps) {
         aria-controls={open() ? listboxId : undefined}
         aria-disabled={props.disabled}
         disabled={props.disabled}
-        class={`flex w-full items-center justify-between gap-2 px-3 py-2 border border-border rounded-md font-body text-[0.85rem] text-foreground bg-background cursor-pointer text-left transition-[border-color,box-shadow] duration-200 hover:border-lavender-500 hover:bg-lavender-50 focus-visible:outline-hidden focus-visible:border-lavender-500 focus-visible:shadow-[0_0_0_3px_rgba(167,139,250,0.15)] disabled:opacity-50 disabled:cursor-not-allowed${props.class ? ` ${props.class}` : ""}`}
+        class={`flex w-full items-center justify-between gap-2 px-3 py-2 border border-border rounded-md font-body text-sm text-foreground bg-background cursor-pointer text-left transition-[border-color,box-shadow] duration-200 hover:border-lavender-500 hover:bg-lavender-50 focus-visible:outline-hidden focus-visible:border-lavender-500 focus-visible:shadow-[0_0_0_3px_rgba(167,139,250,0.15)] disabled:opacity-50 disabled:cursor-not-allowed${props.class ? ` ${props.class}` : ""}`}
         classList={{ "select-trigger-open": open() }}
         onClick={() => (open() ? closeDropdown() : openDropdown())}
         onKeyDown={handleTriggerKeyDown}
@@ -252,7 +252,7 @@ export default function Select(props: SelectProps) {
                   role="option"
                   aria-selected={option.value === props.value}
                   aria-disabled={option.disabled}
-                  class="flex items-center justify-between px-2.5 py-[0.45rem] rounded-sm font-body text-[0.85rem] text-foreground cursor-pointer select-none transition-[background] duration-100 select-option"
+                  class="flex items-center justify-between px-2.5 py-[0.45rem] rounded-sm font-body text-sm text-foreground cursor-pointer select-none transition-[background] duration-100 select-option"
                   classList={{
                     "select-option-selected": option.value === props.value,
                     "select-option-focused": index() === focusedIndex(),

--- a/src/components/ui/button.test.ts
+++ b/src/components/ui/button.test.ts
@@ -5,23 +5,23 @@ describe("buttonVariants", () => {
   it("builds a coral primary button by default", () => {
     const classes = buttonVariants();
 
-    expect(classes).toContain("bg-sp-coral");
+    expect(classes).toContain("bg-coral-500");
     expect(classes).toContain("text-white");
-    expect(classes).toContain("rounded-sp-full");
+    expect(classes).toContain("rounded-full");
   });
 
-  it("supports secondary buttons without a filled tone", () => {
+  it("supports secondary buttons with a coral tone by default", () => {
     const classes = buttonVariants({ variant: "secondary", size: "lg" });
 
-    expect(classes).toContain("border-sp-border");
-    expect(classes).toContain("bg-sp-bg-card");
+    expect(classes).toContain("border-coral-200");
+    expect(classes).toContain("bg-coral-50");
     expect(classes).toContain("px-8");
   });
 
   it("supports mint-toned primary buttons for success actions", () => {
     const classes = buttonVariants({ tone: "mint", fullWidth: true });
 
-    expect(classes).toContain("bg-sp-mint");
+    expect(classes).toContain("bg-mint-500");
     expect(classes).toContain("w-full");
   });
 });

--- a/src/components/ui/button.ts
+++ b/src/components/ui/button.ts
@@ -10,7 +10,7 @@ export interface ButtonVariantProps {
 }
 
 const BASE_BUTTON_CLASSES =
-  "relative inline-flex shrink-0 items-center justify-center gap-2 overflow-hidden whitespace-nowrap rounded-full border-none font-body font-semibold no-underline transition-[transform,box-shadow,background-color] duration-300 outline-hidden focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:shrink-0";
+  "relative inline-flex shrink-0 items-center justify-center gap-2 overflow-hidden whitespace-nowrap rounded-full border-none font-body font-semibold no-underline transition-[transform,box-shadow,background-color] duration-300 ease-out will-change-transform outline-hidden hover:duration-150 focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:shrink-0";
 
 const SIZE_CLASSES: Record<ButtonSize, string> = {
   default: "px-6 py-3 text-lg",
@@ -20,16 +20,16 @@ const SIZE_CLASSES: Record<ButtonSize, string> = {
 
 const PRIMARY_TONE_CLASSES: Record<ButtonTone, string> = {
   coral:
-    "bg-coral-500 text-white shadow-coral hover:bg-coral-600 hover:shadow-[0_6px_24px_rgba(242,90,90,0.4)] hover:-translate-y-[2px] active:translate-y-[1px] active:shadow-sm active:bg-coral-600 active:duration-75",
-  mint: "bg-mint-500 text-white shadow-[0_4px_16px_rgba(26,165,147,0.3)] hover:bg-mint-600 hover:shadow-[0_6px_24px_rgba(26,165,147,0.4)] hover:-translate-y-[2px] active:translate-y-[1px] active:shadow-sm active:bg-mint-600 active:duration-75",
+    "bg-coral-500 text-white shadow-coral hover:bg-coral-400 hover:shadow-[0_6px_24px_rgba(242,90,90,0.4)] hover:-translate-y-[2px] active:translate-y-[1px] active:shadow-sm active:bg-coral-600 active:duration-75",
+  mint: "bg-mint-500 text-white shadow-[0_4px_16px_rgba(26,165,147,0.3)] hover:bg-mint-400 hover:shadow-[0_6px_24px_rgba(26,165,147,0.4)] hover:-translate-y-[2px] active:translate-y-[1px] active:shadow-sm active:bg-mint-600 active:duration-75",
   neutral:
-    "bg-foreground text-white shadow-[0_4px_16px_rgba(30,27,75,0.18)] hover:shadow-[0_6px_24px_rgba(30,27,75,0.24)] hover:-translate-y-[2px] active:translate-y-[1px] active:shadow-sm active:bg-foreground/90 active:duration-75",
+    "bg-foreground text-white shadow-[0_4px_16px_rgba(30,27,75,0.18)] hover:bg-foreground/90 hover:shadow-[0_6px_24px_rgba(30,27,75,0.24)] hover:-translate-y-[2px] active:translate-y-[1px] active:shadow-sm active:bg-foreground active:duration-75",
 };
 
 const SECONDARY_TONE_CLASSES: Record<ButtonTone, string> = {
   coral:
-    "border-coral-200 bg-coral-50 text-coral-600 hover:bg-coral-500 hover:text-white hover:border-coral-500 hover:shadow-md hover:-translate-y-[2px] active:translate-y-[1px] active:shadow-none active:border-border active:duration-75",
-  mint: "border-mint-200 bg-mint-50 text-mint-600 hover:bg-mint-500 hover:text-white hover:border-mint-500 hover:shadow-md hover:-translate-y-[2px] active:translate-y-[1px] active:shadow-none active:border-border active:duration-75",
+    "border-coral-200 bg-coral-50 text-coral-600 hover:bg-coral-400 hover:text-white hover:border-coral-400 hover:shadow-md hover:-translate-y-[2px] active:translate-y-[1px] active:shadow-none active:border-border active:duration-75",
+  mint: "border-mint-200 bg-mint-50 text-mint-600 hover:bg-mint-400 hover:text-white hover:border-mint-400 hover:shadow-md hover:-translate-y-[2px] active:translate-y-[1px] active:shadow-none active:border-border active:duration-75",
   neutral:
     "border-border bg-card text-foreground hover:bg-foreground hover:text-white hover:border-foreground hover:shadow-md hover:-translate-y-[2px] active:translate-y-[1px] active:shadow-none active:border-border active:duration-75",
 };

--- a/src/components/ui/button.ts
+++ b/src/components/ui/button.ts
@@ -13,8 +13,8 @@ const BASE_BUTTON_CLASSES =
   "relative inline-flex shrink-0 items-center justify-center gap-2 overflow-hidden whitespace-nowrap rounded-full border-none font-body font-semibold no-underline transition-[transform,box-shadow,background-color] duration-300 outline-hidden focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:shrink-0";
 
 const SIZE_CLASSES: Record<ButtonSize, string> = {
-  default: "px-6 py-3 text-[1.17rem]",
-  lg: "px-8 py-[0.9rem] text-[1.33rem]",
+  default: "px-6 py-3 text-lg",
+  lg: "px-8 py-4 text-xl",
   icon: "h-10 w-10 rounded-md",
 };
 

--- a/src/components/ui/button.ts
+++ b/src/components/ui/button.ts
@@ -10,27 +10,32 @@ export interface ButtonVariantProps {
 }
 
 const BASE_BUTTON_CLASSES =
-  "relative inline-flex shrink-0 items-center justify-center gap-2 overflow-hidden whitespace-nowrap rounded-sp-full border-none font-body font-semibold no-underline transition-[transform,box-shadow,background-color] duration-300 outline-hidden focus-visible:ring-2 focus-visible:ring-sp-lavender/40 disabled:pointer-events-none disabled:opacity-50 [&_svg]:shrink-0";
+  "relative inline-flex shrink-0 items-center justify-center gap-2 overflow-hidden whitespace-nowrap rounded-full border-none font-body font-semibold no-underline transition-[transform,box-shadow,background-color] duration-300 outline-hidden focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:shrink-0";
 
 const SIZE_CLASSES: Record<ButtonSize, string> = {
   default: "px-6 py-3 text-[1.17rem]",
   lg: "px-8 py-[0.9rem] text-[1.33rem]",
-  icon: "h-10 w-10 rounded-sp",
+  icon: "h-10 w-10 rounded-md",
 };
 
 const PRIMARY_TONE_CLASSES: Record<ButtonTone, string> = {
   coral:
-    "bg-sp-coral text-white shadow-[0_4px_16px_rgba(242,90,90,0.3)] hover:bg-sp-coral-dark hover:shadow-[0_6px_24px_rgba(242,90,90,0.4)] hover:-translate-y-[2px]",
-  mint: "bg-sp-mint text-white shadow-[0_4px_16px_rgba(26,165,147,0.3)] hover:bg-sp-mint-dark hover:shadow-[0_6px_24px_rgba(26,165,147,0.4)] hover:-translate-y-[2px]",
+    "bg-coral-500 text-white shadow-coral hover:bg-coral-600 hover:shadow-[0_6px_24px_rgba(242,90,90,0.4)] hover:-translate-y-[2px] active:translate-y-[1px] active:shadow-sm active:bg-coral-600 active:duration-75",
+  mint: "bg-mint-500 text-white shadow-[0_4px_16px_rgba(26,165,147,0.3)] hover:bg-mint-600 hover:shadow-[0_6px_24px_rgba(26,165,147,0.4)] hover:-translate-y-[2px] active:translate-y-[1px] active:shadow-sm active:bg-mint-600 active:duration-75",
   neutral:
-    "bg-sp-text text-white shadow-[0_4px_16px_rgba(30,27,75,0.18)] hover:shadow-[0_6px_24px_rgba(30,27,75,0.24)] hover:-translate-y-[2px]",
+    "bg-foreground text-white shadow-[0_4px_16px_rgba(30,27,75,0.18)] hover:shadow-[0_6px_24px_rgba(30,27,75,0.24)] hover:-translate-y-[2px] active:translate-y-[1px] active:shadow-sm active:bg-foreground/90 active:duration-75",
 };
 
-const SECONDARY_CLASSES =
-  "border border-sp-border bg-sp-bg-card text-sp-text shadow-sp hover:border-sp-lavender hover:shadow-sp-hover hover:-translate-y-[2px]";
+const SECONDARY_TONE_CLASSES: Record<ButtonTone, string> = {
+  coral:
+    "border-coral-200 bg-coral-50 text-coral-600 hover:bg-coral-500 hover:text-white hover:border-coral-500 hover:shadow-md hover:-translate-y-[2px] active:translate-y-[1px] active:shadow-none active:border-border active:duration-75",
+  mint: "border-mint-200 bg-mint-50 text-mint-600 hover:bg-mint-500 hover:text-white hover:border-mint-500 hover:shadow-md hover:-translate-y-[2px] active:translate-y-[1px] active:shadow-none active:border-border active:duration-75",
+  neutral:
+    "border-border bg-card text-foreground hover:bg-foreground hover:text-white hover:border-foreground hover:shadow-md hover:-translate-y-[2px] active:translate-y-[1px] active:shadow-none active:border-border active:duration-75",
+};
 
 const SHADOW_CLASSES =
-  "border border-sp-border bg-sp-bg text-sp-text shadow-sp-hover hover:border-sp-lavender hover:-translate-y-[2px]";
+  "border border-border bg-background text-foreground shadow-md hover:border-lavender-500 hover:-translate-y-[2px] active:translate-y-[1px] active:shadow-none active:duration-75";
 
 export function buttonVariants({
   variant = "primary",
@@ -42,7 +47,7 @@ export function buttonVariants({
     variant === "primary"
       ? PRIMARY_TONE_CLASSES[tone]
       : variant === "secondary"
-        ? SECONDARY_CLASSES
+        ? SECONDARY_TONE_CLASSES[tone]
         : SHADOW_CLASSES;
 
   return [BASE_BUTTON_CLASSES, SIZE_CLASSES[size], fullWidth ? "w-full" : "", variantClasses]

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -66,7 +66,7 @@ const ogImage = new URL(ogImagePath ?? deriveOgImagePath(Astro.url.pathname), As
   <body>
     <a
       href="#main-content"
-      class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 z-50 p-2 bg-sp-coral text-white rounded-sp font-semibold"
+      class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 z-50 p-2 bg-coral-500 text-white rounded-md font-semibold"
     >
       Skip to main content
     </a>
@@ -118,7 +118,7 @@ const ogImage = new URL(ogImagePath ?? deriveOgImagePath(Astro.url.pathname), As
       if (!btn || btn.hasAttribute("disabled")) return;
 
       const ripple = document.createElement("span");
-      ripple.className = "sp-ripple";
+      ripple.className = "ui-ripple";
       const rect = btn.getBoundingClientRect();
       ripple.style.left = `${e.clientX - rect.left}px`;
       ripple.style.top = `${e.clientY - rect.top}px`;
@@ -143,7 +143,7 @@ const ogImage = new URL(ogImagePath ?? deriveOgImagePath(Astro.url.pathname), As
 </script>
 
 <style>
-  .sp-ripple {
+  .ui-ripple {
     position: absolute;
     border-radius: 50%;
     background: rgba(255, 255, 255, 0.35);

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -23,9 +23,7 @@ import { ROUTES } from "../config/constants";
           <h1 class="font-display text-[var(--font-title)] font-extrabold mt-4 mb-4 tracking-tight">
             Page not found
           </h1>
-          <p
-            class="text-[1.1rem] text-muted-foreground leading-[1.7] m-0 mb-10 max-w-[360px] mx-auto"
-          >
+          <p class="text-lg text-muted-foreground leading-[1.7] m-0 mb-10 max-w-[360px] mx-auto">
             Looks like this page drifted off into the void. Let's get you back on track.
           </p>
           <ButtonLink href={makeHref(ROUTES.HOME)}>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -17,15 +17,15 @@ import { ROUTES } from "../config/constants";
       <div class="max-w-[500px] text-center">
         <div class="opacity-0 animate-error-code">
           <span
-            class="inline-block font-display font-extrabold leading-none bg-linear-to-br from-[var(--sp-coral)] to-[var(--sp-lavender)] bg-clip-text text-transparent error-code"
+            class="inline-block font-display font-extrabold leading-none bg-linear-to-br from-[var(--coral-500)] to-[var(--lavender-500)] bg-clip-text text-transparent error-code"
             >404</span
           >
-          <h1
-            class="font-display text-[var(--sp-font-title)] font-extrabold mt-4 mb-4 tracking-tight"
-          >
+          <h1 class="font-display text-[var(--font-title)] font-extrabold mt-4 mb-4 tracking-tight">
             Page not found
           </h1>
-          <p class="text-[1.1rem] text-sp-text-muted leading-[1.7] m-0 mb-10 max-w-[360px] mx-auto">
+          <p
+            class="text-[1.1rem] text-muted-foreground leading-[1.7] m-0 mb-10 max-w-[360px] mx-auto"
+          >
             Looks like this page drifted off into the void. Let's get you back on track.
           </p>
           <ButtonLink href={makeHref(ROUTES.HOME)}>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -66,11 +66,9 @@ const ABOUT_CARDS = [
         {
           ABOUT_CARDS.map((card) => (
             <AboutCard delay={card.delay}>
-              <h2 class="font-display text-[1.25rem] font-bold mb-4 tracking-tight">
-                {card.title}
-              </h2>
+              <h2 class="font-display text-xl font-bold mb-4 tracking-tight">{card.title}</h2>
               {card.paragraphs.map((p) => (
-                <p class="text-[0.95rem] text-muted-foreground leading-[1.7] mb-4 last:mb-0">{p}</p>
+                <p class="text-sm text-muted-foreground leading-[1.7] mb-4 last:mb-0">{p}</p>
               ))}
               {card.hasTechStack && (
                 <TechStackGrid>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -11,6 +11,42 @@ import PageSection from "../components/ui/PageSection.astro";
 import { Github, ArrowRight } from "lucide-astro";
 import { makeHref } from "../lib/utils";
 import { GITHUB_URL, ROUTES } from "../config/constants";
+
+const ABOUT_CARDS = [
+  {
+    title: "Why I built this",
+    delay: 0,
+    paragraphs: [
+      "Most online image tools require uploading your photos to someone else's server. That means trusting a third party with your personal images, waiting for uploads and downloads, and dealing with file size limits and account requirements.",
+      "I built Reshrimp to prove that you don't need any of that. Modern browsers have everything needed to resize, convert, and compress images — Canvas API, Blob handling, and efficient JavaScript engines. Why send data across the internet when your computer can handle it locally in milliseconds?",
+      "Reshrimp stays intentionally small. It focuses on fast, private, browser-based work for one image at a time: resize, compress, convert, and background removal.",
+    ],
+  },
+  {
+    title: "The tech stack",
+    delay: 100,
+    paragraphs: [
+      "I chose this stack intentionally — it's modern, type-safe, and performant. Each technology serves a specific purpose in building a privacy-first tool.",
+    ],
+    hasTechStack: true,
+  },
+  {
+    title: "Privacy by default",
+    delay: 200,
+    paragraphs: [
+      "I believe software should respect users by default, not as an afterthought. Every pixel of your image stays in your browser — it's never uploaded to a server, never tracked, and never logged. The Canvas API handles everything locally, from resizing to background removal.",
+      "Even AI background removal runs client-side using WebAssembly. Your images are processed on your own device, not on someone else's servers. You can verify this yourself — the code is open source under the MIT license.",
+    ],
+  },
+  {
+    title: "Open source",
+    delay: 300,
+    paragraphs: [
+      "Reshrimp is fully open source. You can read every line of code, fork it to self-host it, or contribute improvements. I welcome pull requests for bug fixes, new features, or documentation updates.",
+    ],
+    hasButtons: true,
+  },
+];
 ---
 
 <MarketingLayout
@@ -27,78 +63,40 @@ import { GITHUB_URL, ROUTES } from "../config/constants";
 
     <PageSection>
       <PageContainer>
-        <AboutCard delay={0}>
-          <h2 class="font-display text-[1.25rem] font-bold mb-4 tracking-tight">
-            Why I built this
-          </h2>
-          <p class="text-[0.95rem] text-sp-text-muted leading-[1.7] mb-4 last:mb-0">
-            Most online image tools require uploading your photos to someone else's server. That
-            means trusting a third party with your personal images, waiting for uploads and
-            downloads, and dealing with file size limits and account requirements.
-          </p>
-          <p class="text-[0.95rem] text-sp-text-muted leading-[1.7] mb-4 last:mb-0">
-            I built Reshrimp to prove that you don't need any of that. Modern browsers have
-            everything needed to resize, convert, and compress images — Canvas API, Blob handling,
-            and efficient JavaScript engines. Why send data across the internet when your computer
-            can handle it locally in milliseconds?
-          </p>
-          <p class="text-[0.95rem] text-sp-text-muted leading-[1.7] mb-4 last:mb-0">
-            Reshrimp stays intentionally small. It focuses on fast, private, browser-based work for
-            one image at a time: resize, compress, convert, and background removal.
-          </p>
-        </AboutCard>
-
-        <AboutCard delay={100}>
-          <h2 class="font-display text-[1.25rem] font-bold mb-4 tracking-tight">The tech stack</h2>
-          <p class="text-[0.95rem] text-sp-text-muted leading-[1.7] mb-4 last:mb-0">
-            I chose this stack intentionally — it's modern, type-safe, and performant. Each
-            technology serves a specific purpose in building a privacy-first tool.
-          </p>
-          <TechStackGrid>
-            <TechStackItem name="Astro" description="Static site framework" />
-            <TechStackItem name="Solid.js" description="Reactive interactive layer" />
-            <TechStackItem name="TypeScript" description="Type-safe processing logic" />
-            <TechStackItem name="Tailwind CSS" description="Utility-first styling" />
-            <TechStackItem name="Vercel" description="Edge deployment platform" />
-            <TechStackItem name="Vitest" description="Unit testing framework" />
-          </TechStackGrid>
-        </AboutCard>
-
-        <AboutCard delay={200}>
-          <h2 class="font-display text-[1.25rem] font-bold mb-4 tracking-tight">
-            Privacy by default
-          </h2>
-          <p class="text-[0.95rem] text-sp-text-muted leading-[1.7] mb-4 last:mb-0">
-            I believe software should respect users by default, not as an afterthought. Every pixel
-            of your image stays in your browser — it's never uploaded to a server, never tracked,
-            and never logged. The Canvas API handles everything locally, from resizing to background
-            removal.
-          </p>
-          <p class="text-[0.95rem] text-sp-text-muted leading-[1.7] mb-4 last:mb-0">
-            Even AI background removal runs client-side using WebAssembly. Your images are processed
-            on your own device, not on someone else's servers. You can verify this yourself — the
-            code is open source under the MIT license.
-          </p>
-        </AboutCard>
-
-        <AboutCard delay={300}>
-          <h2 class="font-display text-[1.25rem] font-bold mb-4 tracking-tight">Open source</h2>
-          <p class="text-[0.95rem] text-sp-text-muted leading-[1.7] mb-4 last:mb-0">
-            Reshrimp is fully open source. You can read every line of code, fork it to self-host it,
-            or contribute improvements. I welcome pull requests for bug fixes, new features, or
-            documentation updates.
-          </p>
-          <div class="flex items-center gap-3 mt-5 flex-wrap">
-            <ButtonLink href={GITHUB_URL} variant="secondary" external={true}>
-              <Github size={18} />
-              View on GitHub
-            </ButtonLink>
-            <ButtonLink href={makeHref(ROUTES.APP)}>
-              Try Reshrimp
-              <ArrowRight size={18} strokeWidth={2} class="cta-pop-arrow" />
-            </ButtonLink>
-          </div>
-        </AboutCard>
+        {
+          ABOUT_CARDS.map((card) => (
+            <AboutCard delay={card.delay}>
+              <h2 class="font-display text-[1.25rem] font-bold mb-4 tracking-tight">
+                {card.title}
+              </h2>
+              {card.paragraphs.map((p) => (
+                <p class="text-[0.95rem] text-muted-foreground leading-[1.7] mb-4 last:mb-0">{p}</p>
+              ))}
+              {card.hasTechStack && (
+                <TechStackGrid>
+                  <TechStackItem name="Astro" description="Static site framework" />
+                  <TechStackItem name="Solid.js" description="Reactive interactive layer" />
+                  <TechStackItem name="TypeScript" description="Type-safe processing logic" />
+                  <TechStackItem name="Tailwind CSS" description="Utility-first styling" />
+                  <TechStackItem name="Vercel" description="Edge deployment platform" />
+                  <TechStackItem name="Vitest" description="Unit testing framework" />
+                </TechStackGrid>
+              )}
+              {card.hasButtons && (
+                <div class="flex items-center gap-3 mt-5 flex-wrap">
+                  <ButtonLink href={GITHUB_URL} variant="secondary" external={true}>
+                    <Github size={18} />
+                    View on GitHub
+                  </ButtonLink>
+                  <ButtonLink href={makeHref(ROUTES.APP)}>
+                    Try Reshrimp
+                    <ArrowRight size={18} strokeWidth={2} class="cta-pop-arrow" />
+                  </ButtonLink>
+                </div>
+              )}
+            </AboutCard>
+          ))
+        }
       </PageContainer>
     </PageSection>
   </MarketingPageWrapper>

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -83,7 +83,7 @@ const faqs = [
         Still have questions?
       </h2>
       <p
-        class="text-[1rem] text-sp-text-muted leading-[1.6] m-0"
+        class="text-[1rem] text-muted-foreground leading-[1.6] m-0"
         data-reveal
         data-reveal-delay="80"
       >

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -79,11 +79,11 @@ const faqs = [
       sectionClass="px-8 py-8 pb-20 text-center relative z-10"
       containerClass="max-w-[500px] mx-auto"
     >
-      <h2 class="font-display text-[1.5rem] font-bold mb-3" data-reveal data-reveal-delay="0">
+      <h2 class="font-display text-2xl font-bold mb-3" data-reveal data-reveal-delay="0">
         Still have questions?
       </h2>
       <p
-        class="text-[1rem] text-muted-foreground leading-[1.6] m-0"
+        class="text-base text-muted-foreground leading-relaxed m-0"
         data-reveal
         data-reveal-delay="80"
       >
@@ -98,7 +98,7 @@ const faqs = [
           Try Reshrimp
           <ArrowRight size={18} strokeWidth={2} class="cta-pop-arrow" />
         </ButtonLink>
-        <ButtonLink href={GITHUB_URL} variant="secondary" size="lg" external={true}>
+        <ButtonLink href={GITHUB_URL} variant="secondary" external={true}>
           <Github size={18} />
           GitHub
         </ButtonLink>

--- a/src/pages/features.astro
+++ b/src/pages/features.astro
@@ -96,7 +96,6 @@ const features = [
     <CTACard
       title="Ready to try it?"
       subtitle="Free, open source, private, and offline-ready after the first visit."
-      background={true}
     />
   </MarketingPageWrapper>
 </MarketingLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -31,6 +31,41 @@ const jsonLd = {
   },
   featureList: ["Image resizing", "Format conversion", "Image compression", "Background removal"],
 };
+
+const BENTO_CARDS = [
+  {
+    color: "coral",
+    colSpan: true,
+    icon: Scaling,
+    title: "Resize with precision",
+    description:
+      "Scale to exact pixel dimensions. Aspect ratio lock keeps everything balanced. Works for uploads, websites, or sharing.",
+  },
+  {
+    color: "mint",
+    colSpan: false,
+    icon: ArrowLeftRight,
+    title: "Convert formats",
+    description:
+      "Switch between JPEG, PNG, WebP, and AVIF in a click. Browser-native conversion with format-specific tradeoffs.",
+  },
+  {
+    color: "lavender",
+    colSpan: false,
+    icon: Gauge,
+    title: "Compress smartly",
+    description:
+      "Fine-tune JPEG, WebP, and AVIF quality from 0-100%. PNG stays lossless. Preview updates after processing so you can review the result before downloading.",
+  },
+  {
+    color: "yellow",
+    colSpan: true,
+    icon: ShieldCheck,
+    title: "Completely private",
+    description:
+      "All processing happens locally via browser APIs. After the first online visit, the app shell and core tools work offline. Open source — verify it yourself.",
+  },
+];
 ---
 
 <MarketingLayout title="Reshrimp — Your Images Deserve Better" currentPath="/">
@@ -54,32 +89,17 @@ const jsonLd = {
     <PageSection sectionClass="px-8 py-16 relative z-10" containerClass="max-w-[1000px] mx-auto">
       <MarketingSectionHeader label="What can you do?" title="Four focused tools for one image." />
       <BentoGrid>
-        <BentoCard
-          color="coral"
-          colSpan={true}
-          icon={Scaling}
-          title="Resize with precision"
-          description="Scale to exact pixel dimensions. Aspect ratio lock keeps everything balanced. Works for uploads, websites, or sharing."
-        />
-        <BentoCard
-          color="mint"
-          icon={ArrowLeftRight}
-          title="Convert formats"
-          description="Switch between JPEG, PNG, WebP, and AVIF in a click. Browser-native conversion with format-specific tradeoffs."
-        />
-        <BentoCard
-          color="lavender"
-          icon={Gauge}
-          title="Compress smartly"
-          description="Fine-tune JPEG, WebP, and AVIF quality from 0-100%. PNG stays lossless. Preview updates after processing so you can review the result before downloading."
-        />
-        <BentoCard
-          color="yellow"
-          colSpan={true}
-          icon={ShieldCheck}
-          title="Completely private"
-          description="All processing happens locally via browser APIs. After the first online visit, the app shell and core tools work offline. Open source — verify it yourself."
-        />
+        {
+          BENTO_CARDS.map((card) => (
+            <BentoCard
+              color={card.color}
+              colSpan={card.colSpan}
+              icon={card.icon}
+              title={card.title}
+              description={card.description}
+            />
+          ))
+        }
       </BentoGrid>
     </PageSection>
 

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -60,20 +60,18 @@ const PRIVACY_CARDS = [
         {
           PRIVACY_CARDS.map((card) => (
             <PrivacyCard>
-              <h2 class="font-display text-[1.25rem] font-bold mb-4 tracking-tight">
-                {card.title}
-              </h2>
+              <h2 class="font-display text-xl font-bold mb-4 tracking-tight">{card.title}</h2>
               {card.paragraphs &&
                 card.paragraphs.map((p) => (
                   <p
-                    class="text-[0.95rem] text-muted-foreground leading-[1.7] mb-4 last:mb-0"
+                    class="text-sm text-muted-foreground leading-[1.7] mb-4 last:mb-0"
                     set:html={p}
                   />
                 ))}
               {card.listItems && (
                 <ul class="list-none p-0 m-0 flex flex-col gap-[0.6rem]">
                   {card.listItems.map((item) => (
-                    <li class="text-[0.95rem] text-muted-foreground leading-[1.6] pl-6 relative before:content-[''] before:absolute before:left-0 before:top-[0.55rem] before:w-2 before:h-2 before:rounded-full before:bg-mint-500">
+                    <li class="text-sm text-muted-foreground leading-relaxed pl-6 relative before:content-[''] before:absolute before:left-0 before:top-[0.55rem] before:w-2 before:h-2 before:rounded-full before:bg-mint-500">
                       {item}
                     </li>
                   ))}

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -6,6 +6,41 @@ import PageContainer from "../components/marketing/layout/PageContainer.astro";
 import HeroSection from "../components/marketing/hero/HeroSection.astro";
 import PrivacyCard from "../components/marketing/cards/PrivacyCard.astro";
 import { GITHUB_URL } from "../config/constants";
+
+const PRIVACY_CARDS = [
+  {
+    title: "How it works technically",
+    paragraphs: [
+      "When you select an image, it stays entirely in your browser's memory. Reshrimp uses browser APIs to read, manipulate, and re-encode your image inside a single browser tab. No image data is sent to any server during processing.",
+      "The processed image is generated as a Blob URL, which exists only in your browser's memory. After the first online visit, the app shell and core tools can also load offline. Background removal downloads its model assets the first time you use it, then can run offline too.",
+    ],
+  },
+  {
+    title: "What we don't do",
+    listItems: [
+      "We don't upload your images anywhere",
+      "We don't use cookies or local storage for tracking",
+      "We don't run analytics scripts (no Google Analytics, no Plausible, nothing)",
+      "We don't require accounts or collect personal information",
+      "We don't upload your image data for processing",
+      "We don't fingerprint your browser or device",
+    ],
+  },
+  {
+    title: "Open source verification",
+    paragraphs: [
+      "Don't take our word for it — read the source code. Reshrimp is fully open source under the MIT license. Every line of code is available for inspection.",
+      `The image-processing logic lives in TypeScript services that you can inspect directly. Check the <a href="${GITHUB_URL}" target="_blank" rel="noopener noreferrer" class="text-coral-500 underline underline-offset-2 decoration-[rgba(242,90,90,0.3)] hover:decoration-coral-500 transition-[text-decoration-color]">GitHub repository</a> to verify our claims.`,
+    ],
+  },
+  {
+    title: "Third-party services",
+    paragraphs: [
+      "Reshrimp is deployed as a static site. The first visit needs a network connection to load the app shell.",
+      "After that, the app shell and core tools work offline. Background removal may download model files once before it can work offline. Those requests are for app or model assets, not for uploading your images.",
+    ],
+  },
+];
 ---
 
 <MarketingLayout
@@ -22,101 +57,31 @@ import { GITHUB_URL } from "../config/constants";
 
     <PageSection>
       <PageContainer>
-        <!-- How it works -->
-        <PrivacyCard>
-          <h2 class="font-display text-[1.25rem] font-bold mb-4 tracking-tight">
-            How it works technically
-          </h2>
-          <p class="text-[0.95rem] text-sp-text-muted leading-[1.7] mb-4 last:mb-0">
-            When you select an image, it stays entirely in your browser's memory. Reshrimp uses
-            browser APIs to read, manipulate, and re-encode your image inside a single browser tab.
-            No image data is sent to any server during processing.
-          </p>
-          <p class="text-[0.95rem] text-sp-text-muted leading-[1.7] mb-4 last:mb-0">
-            The processed image is generated as a Blob URL, which exists only in your browser's
-            memory. After the first online visit, the app shell and core tools can also load
-            offline. Background removal downloads its model assets the first time you use it, then
-            can run offline too.
-          </p>
-        </PrivacyCard>
-
-        <!-- What we don't do -->
-        <PrivacyCard>
-          <h2 class="font-display text-[1.25rem] font-bold mb-4 tracking-tight">
-            What we don't do
-          </h2>
-          <ul class="list-none p-0 m-0 flex flex-col gap-[0.6rem]">
-            <li
-              class="text-[0.95rem] text-sp-text-muted leading-[1.6] pl-6 relative before:content-[''] before:absolute before:left-0 before:top-[0.55rem] before:w-2 before:h-2 before:rounded-full before:bg-sp-mint"
-            >
-              We don't upload your images anywhere
-            </li>
-            <li
-              class="text-[0.95rem] text-sp-text-muted leading-[1.6] pl-6 relative before:content-[''] before:absolute before:left-0 before:top-[0.55rem] before:w-2 before:h-2 before:rounded-full before:bg-sp-mint"
-            >
-              We don't use cookies or local storage for tracking
-            </li>
-            <li
-              class="text-[0.95rem] text-sp-text-muted leading-[1.6] pl-6 relative before:content-[''] before:absolute before:left-0 before:top-[0.55rem] before:w-2 before:h-2 before:rounded-full before:bg-sp-mint"
-            >
-              We don't run analytics scripts (no Google Analytics, no Plausible, nothing)
-            </li>
-            <li
-              class="text-[0.95rem] text-sp-text-muted leading-[1.6] pl-6 relative before:content-[''] before:absolute before:left-0 before:top-[0.55rem] before:w-2 before:h-2 before:rounded-full before:bg-sp-mint"
-            >
-              We don't require accounts or collect personal information
-            </li>
-            <li
-              class="text-[0.95rem] text-sp-text-muted leading-[1.6] pl-6 relative before:content-[''] before:absolute before:left-0 before:top-[0.55rem] before:w-2 before:h-2 before:rounded-full before:bg-sp-mint"
-            >
-              We don't upload your image data for processing
-            </li>
-            <li
-              class="text-[0.95rem] text-sp-text-muted leading-[1.6] pl-6 relative before:content-[''] before:absolute before:left-0 before:top-[0.55rem] before:w-2 before:h-2 before:rounded-full before:bg-sp-mint"
-            >
-              We don't fingerprint your browser or device
-            </li>
-          </ul>
-        </PrivacyCard>
-
-        <!-- Open source -->
-        <PrivacyCard>
-          <h2 class="font-display text-[1.25rem] font-bold mb-4 tracking-tight">
-            Open source verification
-          </h2>
-          <p class="text-[0.95rem] text-sp-text-muted leading-[1.7] mb-4 last:mb-0">
-            Don't take our word for it — read the source code. Reshrimp is fully open source under
-            the MIT license. Every line of code is available for inspection.
-          </p>
-          <p class="text-[0.95rem] text-sp-text-muted leading-[1.7] mb-4 last:mb-0">
-            The image-processing logic lives in TypeScript services that you can inspect directly.
-            Check the
-            <a
-              href={GITHUB_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-              class="text-sp-coral underline underline-offset-2 decoration-[rgba(242,90,90,0.3)] hover:decoration-sp-coral transition-[text-decoration-color]"
-              >GitHub repository</a
-            >
-            to verify our claims.
-          </p>
-        </PrivacyCard>
-
-        <!-- Third-party services -->
-        <PrivacyCard>
-          <h2 class="font-display text-[1.25rem] font-bold mb-4 tracking-tight">
-            Third-party services
-          </h2>
-          <p class="text-[0.95rem] text-sp-text-muted leading-[1.7] mb-4 last:mb-0">
-            Reshrimp is deployed as a static site. The first visit needs a network connection to
-            load the app shell.
-          </p>
-          <p class="text-[0.95rem] text-sp-text-muted leading-[1.7] mb-4 last:mb-0">
-            After that, the app shell and core tools work offline. Background removal may download
-            model files once before it can work offline. Those requests are for app or model assets,
-            not for uploading your images.
-          </p>
-        </PrivacyCard>
+        {
+          PRIVACY_CARDS.map((card) => (
+            <PrivacyCard>
+              <h2 class="font-display text-[1.25rem] font-bold mb-4 tracking-tight">
+                {card.title}
+              </h2>
+              {card.paragraphs &&
+                card.paragraphs.map((p) => (
+                  <p
+                    class="text-[0.95rem] text-muted-foreground leading-[1.7] mb-4 last:mb-0"
+                    set:html={p}
+                  />
+                ))}
+              {card.listItems && (
+                <ul class="list-none p-0 m-0 flex flex-col gap-[0.6rem]">
+                  {card.listItems.map((item) => (
+                    <li class="text-[0.95rem] text-muted-foreground leading-[1.6] pl-6 relative before:content-[''] before:absolute before:left-0 before:top-[0.55rem] before:w-2 before:h-2 before:rounded-full before:bg-mint-500">
+                      {item}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </PrivacyCard>
+          ))
+        }
       </PageContainer>
     </PageSection>
   </MarketingPageWrapper>

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -1,62 +1,62 @@
 /* SolidJS component primitives — loaded only on the /app route */
 
 /* ===== Slider ===== */
-.sp-slider {
+.slider {
   width: 100%;
   height: 6px;
   border-radius: 3px;
   appearance: none;
   -webkit-appearance: none;
-  background: var(--sp-border-light);
+  background: var(--border-light);
   cursor: pointer;
 }
 
-.sp-slider::-webkit-slider-thumb {
+.slider::-webkit-slider-thumb {
   appearance: none;
   -webkit-appearance: none;
   width: 18px;
   height: 18px;
   border-radius: 50%;
-  background: var(--sp-coral);
+  background: var(--coral-500);
   cursor: pointer;
   box-shadow: 0 2px 6px rgba(242, 90, 90, 0.3);
 }
 
-.sp-slider::-moz-range-thumb {
+.slider::-moz-range-thumb {
   width: 18px;
   height: 18px;
   border-radius: 50%;
-  background: var(--sp-coral);
+  background: var(--coral-500);
   border: none;
   cursor: pointer;
   box-shadow: 0 2px 6px rgba(242, 90, 90, 0.3);
 }
 
 /* ===== Select — custom accessible select ===== */
-.sp-select-trigger-open {
-  border-color: var(--sp-lavender);
+.select-trigger-open {
+  border-color: var(--lavender-500);
   box-shadow: 0 0 0 3px rgba(167, 139, 250, 0.15);
 }
 
-.sp-select-chevron-open {
+.select-chevron-open {
   transform: rotate(180deg);
 }
 
-.sp-select-listbox {
+.select-listbox {
   list-style: none;
   margin: 0;
   padding: 0.25rem;
-  background: var(--sp-bg-card);
-  border: 1px solid var(--sp-border);
-  border-radius: var(--sp-radius);
-  box-shadow: var(--sp-shadow-hover);
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
   max-height: 240px;
   overflow-y: auto;
   /* Smooth appear */
-  animation: sp-select-in 0.12s cubic-bezier(0.22, 1, 0.36, 1);
+  animation: select-in 0.12s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
-@keyframes sp-select-in {
+@keyframes select-in {
   from {
     opacity: 0;
     transform: translateY(-4px) scale(0.98);
@@ -67,11 +67,11 @@
   }
 }
 
-.sp-select-listbox-upward {
-  animation: sp-select-in-up 0.12s cubic-bezier(0.22, 1, 0.36, 1);
+.select-listbox-upward {
+  animation: select-in-up 0.12s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
-@keyframes sp-select-in-up {
+@keyframes select-in-up {
   from {
     opacity: 0;
     transform: translateY(4px) scale(0.98);
@@ -82,39 +82,39 @@
   }
 }
 
-.sp-select-option {
+.select-option {
   display: flex;
   align-items: center;
   justify-content: space-between;
   padding: 0.45rem 0.65rem;
-  border-radius: var(--sp-radius-sm);
-  font-family: var(--sp-font-body);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-body);
   font-size: 0.85rem;
-  color: var(--sp-text);
+  color: var(--foreground);
   cursor: pointer;
   user-select: none;
   transition: background 0.1s;
 }
 
-.sp-select-option-focused {
-  background: var(--sp-lavender-light);
-  color: var(--sp-lavender-dark);
+.select-option-focused {
+  background: var(--lavender-50);
+  color: var(--lavender-600);
 }
 
-.sp-select-option-selected {
+.select-option-selected {
   font-weight: 600;
-  color: var(--sp-lavender-dark);
+  color: var(--lavender-600);
 }
 
-.sp-select-option-disabled {
+.select-option-disabled {
   opacity: 0.4;
   cursor: not-allowed;
   pointer-events: none;
 }
 
-.sp-select-check {
+.select-check {
   flex-shrink: 0;
-  color: var(--sp-lavender-dark);
+  color: var(--lavender-600);
 }
 
 /* ===== InfoTooltip ===== */
@@ -127,11 +127,11 @@
   padding: 0.5rem 0.65rem;
   font-size: 0.75rem;
   line-height: 1.4;
-  color: var(--sp-text);
-  background: var(--sp-bg-card);
-  border: 1px solid var(--sp-border);
-  border-radius: var(--sp-radius);
-  box-shadow: var(--sp-shadow-hover);
+  color: var(--foreground);
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
   z-index: 10;
   pointer-events: none;
   display: none;
@@ -149,15 +149,15 @@
   left: 50%;
   transform: translateX(-50%);
   border: 5px solid transparent;
-  border-top-color: var(--sp-border);
+  border-top-color: var(--border);
 }
 
 /* ===== Button Spinner ===== */
-.sp-btn-spinner {
+.btn-spinner {
   width: 1rem;
   height: 1rem;
   border: 2px solid rgba(255, 255, 255, 0.3);
-  border-top-color: var(--sp-bg-card);
+  border-top-color: var(--card);
   border-radius: 50%;
   animation: btn-spin 0.6s linear infinite;
 }
@@ -175,27 +175,27 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: var(--sp-bg);
+  background-color: var(--background);
   background-image:
-    linear-gradient(45deg, var(--sp-border) 25%, transparent 25%),
-    linear-gradient(-45deg, var(--sp-border) 25%, transparent 25%),
-    linear-gradient(45deg, transparent 75%, var(--sp-border) 75%),
-    linear-gradient(-45deg, transparent 75%, var(--sp-border) 75%);
+    linear-gradient(45deg, var(--border) 25%, transparent 25%),
+    linear-gradient(-45deg, var(--border) 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, var(--border) 75%),
+    linear-gradient(-45deg, transparent 75%, var(--border) 75%);
   background-size: 16px 16px;
   background-position:
     0 0,
     0 8px,
     8px -8px,
     -8px 0;
-  border: 1px solid var(--sp-border-light);
-  border-radius: var(--sp-radius);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-md);
 }
 
 /* ===== Preview Feedback ===== */
 .error-container {
-  background: var(--sp-coral-light);
+  background: var(--coral-50);
   border: 1px solid rgba(242, 90, 90, 0.2);
-  border-radius: var(--sp-radius);
+  border-radius: var(--radius-md);
   padding: 1rem 1.25rem;
   margin: 0 1.25rem;
 }
@@ -221,13 +221,13 @@
   z-index: 9999;
 }
 
-.sp-select-listbox-portaled {
+.select-listbox-portaled {
   position: fixed;
   z-index: 9999;
 }
 
 /* ===== Mobile Sheet ===== */
-.sp-mobile-sheet {
+.mobile-sheet {
   height: 80dvh;
   box-shadow:
     0 -4px 24px rgba(30, 27, 75, 0.1),
@@ -236,12 +236,12 @@
   overscroll-behavior: contain;
 }
 
-.sp-mobile-sheet-handle {
+.mobile-sheet-handle {
   width: 36px;
   height: 3px;
-  border-radius: var(--sp-radius-full);
+  border-radius: var(--radius-full);
 }
 
-.sp-mobile-sheet-footer {
+.mobile-sheet-footer {
   padding-bottom: max(0.75rem, env(safe-area-inset-bottom));
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -26,82 +26,209 @@
 
 /* ===== Design Tokens ===== */
 :root {
-  --sp-bg: #f8f7ff;
-  --sp-bg-card: #ffffff;
-  --sp-bg-warm: #fef9f3;
-  --sp-text: #1e1b4b;
-  --sp-text-muted: #6366a1;
-  --sp-text-soft: #9295c5;
-  --sp-coral: #f25a5a;
-  --sp-coral-light: #fff0f0;
-  --sp-coral-dark: #dc4a4a;
-  --sp-mint: #1aa593;
-  --sp-mint-light: #e6faf7;
-  --sp-mint-dark: #138c7b;
-  --sp-lavender: #a78bfa;
-  --sp-lavender-light: #f0edff;
-  --sp-lavender-dark: #8b5cf6;
-  --sp-yellow: #fde68a;
-  --sp-yellow-light: #fefce8;
-  --sp-border: #e0deff;
-  --sp-border-light: #eeedff;
-  --sp-shadow: 0 2px 16px rgba(30, 27, 75, 0.06);
-  --sp-shadow-hover: 0 8px 30px rgba(30, 27, 75, 0.1);
-  --sp-font-display: "Reshrimp Display", "Trebuchet MS", sans-serif;
-  --sp-font-body: "Reshrimp Sans", "Trebuchet MS", sans-serif;
-  --sp-radius: 12px;
-  --sp-radius-lg: 20px;
-  --sp-radius-xl: 28px;
-  --sp-radius-sm: 8px;
-  --sp-radius-full: 999px;
-  --sp-shadow-glow: 0 4px 24px rgba(167, 139, 250, 0.14);
-  --sp-shadow-coral: 0 4px 14px rgba(242, 90, 90, 0.3);
-  --sp-color-validation-warning: #d97706;
-  --sp-color-chip-yellow: #a16207;
-  --sp-font-title: clamp(1.8rem, 4vw, 2.5rem);
-  --sp-duration-fast: 150ms;
-  --sp-duration-normal: 300ms;
-  --sp-duration-slow: 500ms;
-  --sp-content-max-width: 1100px;
-}
+  --background: oklch(0.9792 0.0106 291.96);
+  --card: oklch(1 0 0);
+  --warm: oklch(0.9843 0.0096 72.66);
+  --foreground: oklch(0.2573 0.0861 281.29);
+  --muted-foreground: oklch(0.5334 0.092 280.57);
+  --soft-foreground: oklch(0.6849 0.0706 281.57);
+  --border: oklch(0.9124 0.0448 288.26);
+  --border-light: oklch(0.9522 0.0241 288.49);
 
-@theme {
-  --color-sp-bg: #f8f7ff;
-  --color-sp-bg-card: #ffffff;
-  --color-sp-bg-warm: #fef9f3;
-  --color-sp-text: #1e1b4b;
-  --color-sp-text-muted: #6366a1;
-  --color-sp-text-soft: #9295c5;
-  --color-sp-coral: #f25a5a;
-  --color-sp-coral-light: #fff0f0;
-  --color-sp-coral-dark: #dc4a4a;
-  --color-sp-mint: #1aa593;
-  --color-sp-mint-light: #e6faf7;
-  --color-sp-mint-dark: #138c7b;
-  --color-sp-lavender: #a78bfa;
-  --color-sp-lavender-light: #f0edff;
-  --color-sp-lavender-dark: #8b5cf6;
-  --color-sp-yellow: #fde68a;
-  --color-sp-yellow-light: #fefce8;
-  --color-sp-border: #e0deff;
-  --color-sp-border-light: #eeedff;
+  --coral-50: oklch(0.9395 0.0306 30.18);
+  --coral-100: oklch(0.9031 0.0502 25.71);
+  --coral-200: oklch(0.847 0.0834 24.41);
+  --coral-300: oklch(0.7761 0.1311 23.9);
+  --coral-400: oklch(0.7 0.161 23.44);
+  --coral-500: oklch(0.6682 0.1874 23.67);
+  --coral-600: oklch(0.5502 0.1726 23.73);
+  --coral-700: oklch(0.451 0.1573 23.62);
+  --coral-800: oklch(0.3503 0.1416 23.68);
+  --coral-900: oklch(0.2662 0.1092 29.23);
+  --coral-950: oklch(0.209 0.0858 29.23);
+
+  --mint-50: oklch(0.9703 0.0414 181.62);
+  --mint-100: oklch(0.9295 0.0487 181.98);
+  --mint-200: oklch(0.8705 0.065 181.41);
+  --mint-300: oklch(0.7806 0.0814 180.6);
+  --mint-400: oklch(0.6997 0.0966 181.31);
+  --mint-500: oklch(0.6496 0.1124 181.09);
+  --mint-600: oklch(0.5527 0.1 180.45);
+  --mint-700: oklch(0.4569 0.0835 179.01);
+  --mint-800: oklch(0.3594 0.0661 178.14);
+  --mint-900: oklch(0.2621 0.0486 176.97);
+  --mint-950: oklch(0.1941 0.0373 172.82);
+
+  --lavender-50: oklch(0.9603 0.0241 306.97);
+  --lavender-100: oklch(0.9232 0.0427 298.82);
+  --lavender-200: oklch(0.8651 0.0753 296.68);
+  --lavender-300: oklch(0.7801 0.1149 293.77);
+  --lavender-400: oklch(0.6994 0.1375 293.67);
+  --lavender-500: oklch(0.709 0.1592 293.54);
+  --lavender-600: oklch(0.5503 0.1465 293.34);
+  --lavender-700: oklch(0.4501 0.1338 293.91);
+  --lavender-800: oklch(0.3501 0.1201 293.06);
+  --lavender-900: oklch(0.2488 0.1087 293.22);
+  --lavender-950: oklch(0.1821 0.101 293.35);
+
+  --yellow-50: oklch(0.9704 0.0423 96.92);
+  --yellow-100: oklch(0.9293 0.0508 94.97);
+  --yellow-200: oklch(0.8705 0.0667 96.19);
+  --yellow-300: oklch(0.7808 0.0827 96.19);
+  --yellow-400: oklch(0.6998 0.0992 95.61);
+  --yellow-500: oklch(0.9243 0.1151 95.75);
+  --yellow-600: oklch(0.5485 0.1057 95.59);
+  --yellow-700: oklch(0.4507 0.0925 94.58);
+  --yellow-800: oklch(0.3507 0.0718 92.27);
+  --yellow-900: oklch(0.2524 0.0516 86.43);
+  --yellow-950: oklch(0.1822 0.0386 74.19);
+
+  --primary: var(--coral-500);
+  --primary-foreground: oklch(1 0 0);
+  --secondary: var(--mint-500);
+  --secondary-foreground: oklch(1 0 0);
+  --accent: var(--lavender-500);
+  --accent-foreground: oklch(1 0 0);
+  --destructive: var(--coral-500);
+  --destructive-foreground: oklch(1 0 0);
+  --success: var(--mint-500);
+  --success-foreground: oklch(1 0 0);
+  --warning: var(--yellow-500);
+  --warning-foreground: var(--foreground);
+  --info: var(--lavender-500);
+  --info-foreground: oklch(1 0 0);
+  --ring: oklch(0.709 0.1592 293.54 / 0.4);
+
+  --shadow-2xs: 0 1px 2px oklch(0.2573 0.0861 281.29 / 0.04);
+  --shadow-xs: 0 2px 8px oklch(0.2573 0.0861 281.29 / 0.05);
+  --shadow-sm: 0 2px 16px oklch(0.2573 0.0861 281.29 / 0.06);
+  --shadow-md: 0 8px 30px oklch(0.2573 0.0861 281.29 / 0.1);
+  --shadow-lg: 0 12px 40px oklch(0.2573 0.0861 281.29 / 0.12);
+  --shadow-xl: 0 20px 60px oklch(0.2573 0.0861 281.29 / 0.15);
+  --shadow-glow: 0 4px 24px oklch(0.709 0.1592 293.54 / 0.14);
+  --shadow-coral: 0 4px 14px oklch(0.6682 0.1874 23.67 / 0.3);
 
   --font-display: "Reshrimp Display", "Trebuchet MS", sans-serif;
   --font-body: "Reshrimp Sans", "Trebuchet MS", sans-serif;
+  --font-mono: "SF Mono", Menlo, Consolas, monospace;
 
-  --radius-sp: 12px;
-  --radius-sp-lg: 20px;
-  --radius-sp-xl: 28px;
-  --radius-sp-full: 999px;
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 20px;
+  --radius-xl: 28px;
+  --radius-full: 999px;
 
-  --shadow-sp: 0 2px 16px rgba(30, 27, 75, 0.06);
-  --shadow-sp-hover: 0 8px 30px rgba(30, 27, 75, 0.1);
+  --ease-pop: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --duration-fast: 150ms;
+  --duration-normal: 300ms;
+  --duration-slow: 500ms;
 
-  --radius-sp-sm: 8px;
-  --shadow-sp-glow: 0 4px 24px rgba(167, 139, 250, 0.14);
-  --shadow-sp-coral: 0 4px 14px rgba(242, 90, 90, 0.3);
-  --color-sp-validation-warning: #d97706;
-  --color-sp-chip-yellow: #a16207;
+  --font-title: clamp(1.8rem, 4vw, 2.5rem);
+  --validation-warning: #d97706;
+  --chip-yellow: #a16207;
+  --content-max-width: 1100px;
+}
+
+@theme {
+  --color-background: oklch(0.9792 0.0106 291.96);
+  --color-card: oklch(1 0 0);
+  --color-warm: oklch(0.9843 0.0096 72.66);
+  --color-foreground: oklch(0.2573 0.0861 281.29);
+  --color-muted-foreground: oklch(0.5334 0.092 280.57);
+  --color-soft-foreground: oklch(0.6849 0.0706 281.57);
+  --color-border: oklch(0.9124 0.0448 288.26);
+  --color-border-light: oklch(0.9522 0.0241 288.49);
+
+  --color-coral-50: oklch(0.9395 0.0306 30.18);
+  --color-coral-100: oklch(0.9031 0.0502 25.71);
+  --color-coral-200: oklch(0.847 0.0834 24.41);
+  --color-coral-300: oklch(0.7761 0.1311 23.9);
+  --color-coral-400: oklch(0.7 0.161 23.44);
+  --color-coral-500: oklch(0.6682 0.1874 23.67);
+  --color-coral-600: oklch(0.5502 0.1726 23.73);
+  --color-coral-700: oklch(0.451 0.1573 23.62);
+  --color-coral-800: oklch(0.3503 0.1416 23.68);
+  --color-coral-900: oklch(0.2662 0.1092 29.23);
+  --color-coral-950: oklch(0.209 0.0858 29.23);
+
+  --color-mint-50: oklch(0.9703 0.0414 181.62);
+  --color-mint-100: oklch(0.9295 0.0487 181.98);
+  --color-mint-200: oklch(0.8705 0.065 181.41);
+  --color-mint-300: oklch(0.7806 0.0814 180.6);
+  --color-mint-400: oklch(0.6997 0.0966 181.31);
+  --color-mint-500: oklch(0.6496 0.1124 181.09);
+  --color-mint-600: oklch(0.5527 0.1 180.45);
+  --color-mint-700: oklch(0.4569 0.0835 179.01);
+  --color-mint-800: oklch(0.3594 0.0661 178.14);
+  --color-mint-900: oklch(0.2621 0.0486 176.97);
+  --color-mint-950: oklch(0.1941 0.0373 172.82);
+
+  --color-lavender-50: oklch(0.9603 0.0241 306.97);
+  --color-lavender-100: oklch(0.9232 0.0427 298.82);
+  --color-lavender-200: oklch(0.8651 0.0753 296.68);
+  --color-lavender-300: oklch(0.7801 0.1149 293.77);
+  --color-lavender-400: oklch(0.6994 0.1375 293.67);
+  --color-lavender-500: oklch(0.709 0.1592 293.54);
+  --color-lavender-600: oklch(0.5503 0.1465 293.34);
+  --color-lavender-700: oklch(0.4501 0.1338 293.91);
+  --color-lavender-800: oklch(0.3501 0.1201 293.06);
+  --color-lavender-900: oklch(0.2488 0.1087 293.22);
+  --color-lavender-950: oklch(0.1821 0.101 293.35);
+
+  --color-yellow-50: oklch(0.9704 0.0423 96.92);
+  --color-yellow-100: oklch(0.9293 0.0508 94.97);
+  --color-yellow-200: oklch(0.8705 0.0667 96.19);
+  --color-yellow-300: oklch(0.7808 0.0827 96.19);
+  --color-yellow-400: oklch(0.6998 0.0992 95.61);
+  --color-yellow-500: oklch(0.9243 0.1151 95.75);
+  --color-yellow-600: oklch(0.5485 0.1057 95.59);
+  --color-yellow-700: oklch(0.4507 0.0925 94.58);
+  --color-yellow-800: oklch(0.3507 0.0718 92.27);
+  --color-yellow-900: oklch(0.2524 0.0516 86.43);
+  --color-yellow-950: oklch(0.1822 0.0386 74.19);
+
+  --color-primary: var(--color-coral-500);
+  --color-primary-foreground: oklch(1 0 0);
+  --color-secondary: var(--color-mint-500);
+  --color-secondary-foreground: oklch(1 0 0);
+  --color-accent: var(--color-lavender-500);
+  --color-accent-foreground: oklch(1 0 0);
+  --color-destructive: var(--color-coral-500);
+  --color-destructive-foreground: oklch(1 0 0);
+  --color-success: var(--color-mint-500);
+  --color-success-foreground: oklch(1 0 0);
+  --color-warning: var(--color-yellow-500);
+  --color-warning-foreground: var(--color-foreground);
+  --color-info: var(--color-lavender-500);
+  --color-info-foreground: oklch(1 0 0);
+  --color-ring: oklch(0.709 0.1592 293.54 / 0.4);
+
+  --font-display: "Reshrimp Display", "Trebuchet MS", sans-serif;
+  --font-body: "Reshrimp Sans", "Trebuchet MS", sans-serif;
+  --font-mono: "SF Mono", Menlo, Consolas, monospace;
+
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 20px;
+  --radius-xl: 28px;
+  --radius-full: 999px;
+
+  --shadow-2xs: 0 1px 2px oklch(0.2573 0.0861 281.29 / 0.04);
+  --shadow-xs: 0 2px 8px oklch(0.2573 0.0861 281.29 / 0.05);
+  --shadow-sm: 0 2px 16px oklch(0.2573 0.0861 281.29 / 0.06);
+  --shadow-md: 0 8px 30px oklch(0.2573 0.0861 281.29 / 0.1);
+  --shadow-lg: 0 12px 40px oklch(0.2573 0.0861 281.29 / 0.12);
+  --shadow-xl: 0 20px 60px oklch(0.2573 0.0861 281.29 / 0.15);
+  --shadow-glow: 0 4px 24px oklch(0.709 0.1592 293.54 / 0.14);
+  --shadow-coral: 0 4px 14px oklch(0.6682 0.1874 23.67 / 0.3);
+
+  --ease-pop: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --duration-fast: 150ms;
+  --duration-normal: 300ms;
+  --duration-slow: 500ms;
+
+  --color-validation-warning: #d97706;
+  --color-chip-yellow: #a16207;
 }
 
 /* ===== Base Element Styles ===== */
@@ -125,9 +252,9 @@ html {
 }
 
 body {
-  font-family: var(--sp-font-body);
-  background: var(--sp-bg);
-  color: var(--sp-text);
+  font-family: var(--font-body);
+  background: var(--background);
+  color: var(--foreground);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
@@ -142,8 +269,8 @@ h6 {
 }
 
 ::selection {
-  background: var(--sp-lavender);
-  color: var(--sp-bg-card);
+  background: var(--lavender-500);
+  color: var(--card);
 }
 
 /* ===== Shared Animations ===== */
@@ -155,6 +282,20 @@ h6 {
   to {
     opacity: 1;
     transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes softPop {
+  0% {
+    opacity: 0;
+    transform: scale(0.96) translateY(12px);
+  }
+  60% {
+    transform: scale(1.02);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1) translateY(0);
   }
 }
 


### PR DESCRIPTION
## Summary
Migrates the entire design system from ad-hoc `sp-` prefixed tokens to a unified semantic token system using oklch color scales. Adds active states to buttons, creates a generic Card primitive, refactors repetitive marketing sections to loop over constant arrays, and standardizes the type scale to Tailwind defaults.

## Changes
- Migrate CSS custom properties and Tailwind theme tokens to semantic bare names
- Convert core brand colors to oklch with 50-950 scales (coral, mint, lavender, yellow)
- Add semantic aliases (primary, secondary, accent, destructive, success, warning, info)
- Add elevation shadow scale and easing tokens
- Add canonical `softPop` keyframe animation
- Create generic `Card.astro` primitive with variant support
- Add `:active` states and tone support to all Button variants
- Refactor About, Privacy, and Bento cards to use `Card.astro`
- Refactor About, Privacy, and Index pages to loop over constant arrays
- **Standardize type scale**: replace all arbitrary `text-[...rem]` with Tailwind defaults
- **Fix button sizing**: default `text-lg`, lg `text-xl` instead of oversized rem values
- **Fix FAQ buttons**: both default size (was mismatched lg vs default)
- **Fix BentoCard hover**: subtle shadow only, no cursor-pointer or lift
- **Fix StepSection layout**: mobile column, desktop row
- **Fix CTACard**: always use card background, remove `background` prop
- Update all app components, layouts, and shared components to new tokens

## Testing
**Automated**
- [x] `bun run verify` passed (145 tests, type-check, lint, format, build)

## Notes
No functional behavior was changed. All modifications are token renames, structural refactors, and visual consistency fixes. The existing `sp-` prefix has been completely removed from the codebase.