### PR TITLE
fix: replace invalid dependabot auto-merge config with actions workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,6 @@ updates:
         update-types:
           - "minor"
           - "patch"
-        auto-merge: "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -44,4 +43,3 @@ updates:
         update-types:
           - "minor"
           - "patch"
-        auto-merge: "*"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,27 +1,3 @@
-# -------------------------------------------------------------------
-# Dependabot auto-merge workflow
-#
-# Automatically enables merge-on-green for Dependabot pull requests
-# that update non-major dependencies (patch and minor).
-#
-# Requires a fine-grained PAT stored as a repository secret named
-# DEPENDABOT_AUTOMERGE_PAT.  Required token permissions:
-#   - Pull requests: Read and Write
-#   - Contents: Read (already default for fine-grained tokens)
-#
-# The PAT must belong to a user who has write access to the repo
-# (needed for the merge action).
-#
-# Why a PAT instead of GITHUB_TOKEN?
-# When a workflow is triggered by dependabot[bot], the built-in
-# GITHUB_TOKEN has read-only permissions for contents and
-# pull-requests, even if the workflow YAML requests write.  A PAT
-# bypasses this restriction and allows `gh pr merge --auto` to work.
-#
-# Reference: https://docs.github.com/en/code-security/dependabot/
-#   working-with-dependabot/automating-dependabot-with-github-actions
-# -------------------------------------------------------------------
-
 name: Dependabot auto-merge
 
 on:
@@ -35,8 +11,7 @@ jobs:
   dependabot:
     runs-on: ubuntu-latest
 
-    # Only act on PRs opened by Dependabot itself.
-    # Update the repository check to match your org/repo.
+    # Only act on Dependabot PRs in this repo.
     if: >
       github.event.pull_request.user.login == 'dependabot[bot]'
       && github.repository == 'abijith-suresh/reshrimp'
@@ -48,8 +23,7 @@ jobs:
         with:
           github-token: "${{ secrets.DEPENDABOT_AUTOMERGE_PAT }}"
 
-      # Enable auto-merge for patch and minor updates.
-      # Major-version bumps are skipped — they deserve a human look.
+      # Skip major bumps — they deserve human review.
       - name: Enable auto-merge for patch and minor updates
         if: >
           steps.metadata.outputs.update-type == 'version-update:semver-patch'

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -4,9 +4,13 @@
 # Automatically enables merge-on-green for Dependabot pull requests
 # that update non-major dependencies (patch and minor).
 #
-# Requires a PAT (classic) with `repo` scope stored as a repository
-# secret named `DEPENDABOT_AUTOMERGE_PAT`.  The PAT must belong to a
-# user who has write access to the repository.
+# Requires a fine-grained PAT stored as a repository secret named
+# DEPENDABOT_AUTOMERGE_PAT.  Required token permissions:
+#   - Pull requests: Read and Write
+#   - Contents: Read (already default for fine-grained tokens)
+#
+# The PAT must belong to a user who has write access to the repo
+# (needed for the merge action).
 #
 # Why a PAT instead of GITHUB_TOKEN?
 # When a workflow is triggered by dependabot[bot], the built-in

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,56 @@
+# -------------------------------------------------------------------
+# Dependabot auto-merge workflow
+#
+# Automatically enables merge-on-green for Dependabot pull requests
+# that update non-major dependencies (patch and minor).
+#
+# Requires a PAT (classic) with `repo` scope stored as a repository
+# secret named `DEPENDABOT_AUTOMERGE_PAT`.  The PAT must belong to a
+# user who has write access to the repository.
+#
+# Why a PAT instead of GITHUB_TOKEN?
+# When a workflow is triggered by dependabot[bot], the built-in
+# GITHUB_TOKEN has read-only permissions for contents and
+# pull-requests, even if the workflow YAML requests write.  A PAT
+# bypasses this restriction and allows `gh pr merge --auto` to work.
+#
+# Reference: https://docs.github.com/en/code-security/dependabot/
+#   working-with-dependabot/automating-dependabot-with-github-actions
+# -------------------------------------------------------------------
+
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+
+    # Only act on PRs opened by Dependabot itself.
+    # Update the repository check to match your org/repo.
+    if: >
+      github.event.pull_request.user.login == 'dependabot[bot]'
+      && github.repository == 'abijith-suresh/reshrimp'
+
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7 # v3
+        with:
+          github-token: "${{ secrets.DEPENDABOT_AUTOMERGE_PAT }}"
+
+      # Enable auto-merge for patch and minor updates.
+      # Major-version bumps are skipped — they deserve a human look.
+      - name: Enable auto-merge for patch and minor updates
+        if: >
+          steps.metadata.outputs.update-type == 'version-update:semver-patch'
+          || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.DEPENDABOT_AUTOMERGE_PAT }}


### PR DESCRIPTION
## Problem

The `auto-merge: "*"` key under `groups` in `.github/dependabot.yml` is **not a valid Dependabot configuration option**. GitHubs built-in config validation (the `.github/dependabot.yml` check) rejects it on every PR — including release-please PRs like #163.

## Solution

Two changes:

### 1. Remove invalid config from `.github/dependabot.yml`

Delete `auto-merge: "*"` from both the `bun` and `github-actions` update groups. Dependabot does not support an `auto-merge` field in its schema.

### 2. New workflow: `.github/workflows/dependabot-auto-merge.yml`

A dedicated GitHub Actions workflow that:
- Triggers on `pull_request` events
- Scopes itself to PRs authored by `dependabot[bot]`
- Uses `dependabot/fetch-metadata@v3` to inspect the update type
- Enables auto-merge (`gh pr merge --auto --merge`) for **patch and minor** updates only
- Uses a **PAT** (`DEPENDABOT_AUTOMERGE_PAT`) instead of `GITHUB_TOKEN`

### Why a PAT?

When a workflow is triggered by `dependabot[bot]`, GitHub restricts the built-in `GITHUB_TOKEN` to read-only for `contents` and `pull-requests` — even if the workflow YAML requests write. A classic PAT with `repo` scope bypasses this and allows `gh pr merge --auto` to actually enable auto-merge.

## Setup required

Before merging, create a repository secret named `DEPENDABOT_AUTOMERGE_PAT` containing a classic PAT with `repo` scope from a user who has write access to this repo. See the PR description companion guide for step-by-step instructions.

Closes the failing `.github/dependabot.yml` check on PR #163.
